### PR TITLE
fix: remove pnpm version from workflow to use package.json packageMan…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
…ager

The workflow was specifying version 9 while package.json has packageManager: "pnpm@9.15.4". This caused the build to fail with ERR_PNPM_BAD_PM_VERSION. pnpm/action-setup@v4 will auto-detect the version from package.json.

https://claude.ai/code/session_01CqM3LXtnGWstEg6vP6GaR1