### PR TITLE
Add permissions to Claude code action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   claude:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+      issues: write
     steps:
       - uses: anthropics/claude-code-action@v1
         with:


### PR DESCRIPTION
## Summary
Updated the Claude code action workflow to explicitly declare required permissions for the GitHub Actions job.

## Changes
- Added `permissions` block to the `claude` job in `.github/workflows/claude.yml`
- Granted the following permissions:
  - `id-token: write` - Required for OIDC token generation
  - `contents: write` - Required to read and write repository contents
  - `pull-requests: write` - Required to create and update pull requests
  - `issues: write` - Required to create and update issues

## Details
This change follows GitHub Actions security best practices by explicitly declaring the minimum required permissions for the workflow job. This improves security posture by using the principle of least privilege and makes the workflow's requirements transparent. The permissions are necessary for the Claude code action to function properly when interacting with the repository.