### PR TITLE
feat: add extensible font system with lazy loading to RSVP reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ CHANGELOG.md
 .turbo
 .vite
 *.tsbuildinfo
+package-lock.json

--- a/apps/rsvp-reader/src/fonts/fontConfig.ts
+++ b/apps/rsvp-reader/src/fonts/fontConfig.ts
@@ -1,0 +1,89 @@
+/**
+ * Font configuration for RSVP Reader
+ * Supports both local and remote (Google Fonts) fonts with lazy loading
+ */
+
+export type FontSource = 'local' | 'google';
+
+export interface FontConfig {
+  id: string;
+  name: string;
+  displayName: string;
+  source: FontSource;
+  cssClass: string;
+  // For Google Fonts
+  googleFontUrl?: string;
+  // For local fonts
+  localFontPath?: string;
+  fontFace?: string;
+}
+
+/**
+ * Available fonts for RSVP Reader
+ * Add new fonts here to make them available in the UI
+ */
+export const AVAILABLE_FONTS: FontConfig[] = [
+  {
+    id: 'system-mono',
+    name: 'System Monospace',
+    displayName: 'System Mono',
+    source: 'local',
+    cssClass: 'font-mono',
+  },
+  {
+    id: 'jetbrains-mono',
+    name: 'JetBrains Mono',
+    displayName: 'JetBrains Mono',
+    source: 'local',
+    cssClass: 'font-jetbrains',
+    localFontPath: '/JetBrainsMono-2.304/fonts/webfonts',
+    fontFace: `
+      @font-face {
+        font-family: 'JetBrains Mono';
+        src: url('/JetBrainsMono-2.304/fonts/webfonts/JetBrainsMono-Regular.woff2') format('woff2');
+        font-weight: 400;
+        font-style: normal;
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'JetBrains Mono';
+        src: url('/JetBrainsMono-2.304/fonts/webfonts/JetBrainsMono-Bold.woff2') format('woff2');
+        font-weight: 700;
+        font-style: normal;
+        font-display: swap;
+      }
+    `,
+  },
+  {
+    id: 'cascadia-code',
+    name: 'Cascadia Code',
+    displayName: 'Cascadia Code',
+    source: 'google',
+    cssClass: 'font-cascadia',
+    googleFontUrl: 'https://fonts.googleapis.com/css2?family=Cascadia+Code:wght@400;700&display=swap',
+  },
+  {
+    id: 'special-elite',
+    name: 'Special Elite',
+    displayName: 'Special Elite',
+    source: 'google',
+    cssClass: 'font-special-elite',
+    googleFontUrl: 'https://fonts.googleapis.com/css2?family=Special+Elite&display=swap',
+  },
+];
+
+export const DEFAULT_FONT_ID = 'jetbrains-mono';
+
+/**
+ * Get font configuration by ID
+ */
+export function getFontById(id: string): FontConfig | undefined {
+  return AVAILABLE_FONTS.find(font => font.id === id);
+}
+
+/**
+ * Get default font configuration
+ */
+export function getDefaultFont(): FontConfig {
+  return getFontById(DEFAULT_FONT_ID) || AVAILABLE_FONTS[0];
+}

--- a/apps/rsvp-reader/src/fonts/fontLoader.ts
+++ b/apps/rsvp-reader/src/fonts/fontLoader.ts
@@ -1,0 +1,169 @@
+/**
+ * Font loader utility for lazy loading fonts on demand
+ */
+
+import type { FontConfig } from './fontConfig';
+
+/**
+ * Track which fonts have been loaded to avoid duplicate loading
+ */
+const loadedFonts = new Set<string>();
+
+/**
+ * Track pending font loads to avoid duplicate requests
+ */
+const pendingLoads = new Map<string, Promise<void>>();
+
+/**
+ * Load a font lazily based on its configuration
+ * @param fontConfig - Font configuration to load
+ * @returns Promise that resolves when font is loaded
+ */
+export async function loadFont(fontConfig: FontConfig): Promise<void> {
+  // Check if already loaded
+  if (loadedFonts.has(fontConfig.id)) {
+    return;
+  }
+
+  // Check if already loading
+  const pendingLoad = pendingLoads.get(fontConfig.id);
+  if (pendingLoad) {
+    return pendingLoad;
+  }
+
+  // System fonts don't need loading
+  if (fontConfig.source === 'local' && !fontConfig.fontFace) {
+    loadedFonts.add(fontConfig.id);
+    return;
+  }
+
+  // Create loading promise
+  const loadPromise = (async () => {
+    try {
+      if (fontConfig.source === 'google' && fontConfig.googleFontUrl) {
+        await loadGoogleFont(fontConfig);
+      } else if (fontConfig.source === 'local' && fontConfig.fontFace) {
+        await loadLocalFont(fontConfig);
+      }
+
+      loadedFonts.add(fontConfig.id);
+    } catch (error) {
+      console.error(`Failed to load font ${fontConfig.name}:`, error);
+      throw error;
+    } finally {
+      pendingLoads.delete(fontConfig.id);
+    }
+  })();
+
+  pendingLoads.set(fontConfig.id, loadPromise);
+  return loadPromise;
+}
+
+/**
+ * Load a Google Font by injecting a link element
+ */
+function loadGoogleFont(fontConfig: FontConfig): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!fontConfig.googleFontUrl) {
+      reject(new Error('Google Font URL not provided'));
+      return;
+    }
+
+    // Check if link already exists
+    const existingLink = document.querySelector(
+      `link[href="${fontConfig.googleFontUrl}"]`
+    );
+    if (existingLink) {
+      resolve();
+      return;
+    }
+
+    // Add preconnect links for Google Fonts if not already present
+    if (!document.querySelector('link[href="https://fonts.googleapis.com"]')) {
+      const preconnect1 = document.createElement('link');
+      preconnect1.rel = 'preconnect';
+      preconnect1.href = 'https://fonts.googleapis.com';
+      document.head.appendChild(preconnect1);
+
+      const preconnect2 = document.createElement('link');
+      preconnect2.rel = 'preconnect';
+      preconnect2.href = 'https://fonts.gstatic.com';
+      preconnect2.crossOrigin = 'anonymous';
+      document.head.appendChild(preconnect2);
+    }
+
+    // Create and inject link element
+    const link = document.createElement('link');
+    link.rel = 'stylesheet';
+    link.href = fontConfig.googleFontUrl;
+
+    link.onload = () => {
+      // Wait a bit for font to be available
+      setTimeout(() => resolve(), 100);
+    };
+
+    link.onerror = () => {
+      reject(new Error(`Failed to load Google Font: ${fontConfig.name}`));
+    };
+
+    document.head.appendChild(link);
+  });
+}
+
+/**
+ * Load a local font by injecting CSS @font-face rules
+ */
+function loadLocalFont(fontConfig: FontConfig): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!fontConfig.fontFace) {
+      reject(new Error('Font face definition not provided'));
+      return;
+    }
+
+    // Check if style element already exists
+    const styleId = `font-${fontConfig.id}`;
+    const existingStyle = document.getElementById(styleId);
+    if (existingStyle) {
+      resolve();
+      return;
+    }
+
+    // Create and inject style element
+    const style = document.createElement('style');
+    style.id = styleId;
+    style.textContent = fontConfig.fontFace;
+    document.head.appendChild(style);
+
+    // Wait for fonts to load using Font Loading API
+    if ('fonts' in document) {
+      document.fonts.ready
+        .then(() => {
+          resolve();
+        })
+        .catch((error) => {
+          console.warn('Font loading API error:', error);
+          // Still resolve as font may be loaded
+          resolve();
+        });
+    } else {
+      // Fallback: wait a bit for font to be available
+      setTimeout(() => resolve(), 100);
+    }
+  });
+}
+
+/**
+ * Check if a font is loaded
+ */
+export function isFontLoaded(fontId: string): boolean {
+  return loadedFonts.has(fontId);
+}
+
+/**
+ * Preload a font (useful for prefetching)
+ */
+export function preloadFont(fontConfig: FontConfig): void {
+  loadFont(fontConfig).catch((error) => {
+    console.warn(`Failed to preload font ${fontConfig.name}:`, error);
+  });
+}

--- a/apps/rsvp-reader/src/index.css
+++ b/apps/rsvp-reader/src/index.css
@@ -17,3 +17,16 @@
   --color-primary: 220 90% 60%;
   --color-primary-foreground: 0 0% 100%;
 }
+
+/* Font family classes for RSVP Reader */
+.font-jetbrains {
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.font-cascadia {
+  font-family: 'Cascadia Code', monospace;
+}
+
+.font-special-elite {
+  font-family: 'Special Elite', monospace;
+}


### PR DESCRIPTION
- Create font configuration system supporting local and Google Fonts
- Implement lazy font loading utility to load fonts on demand
- Add font selector UI in RSVPReader header with dropdown
- Support JetBrains Mono (default), Cascadia Code, Special Elite, and System Mono
- Persist font selection to localStorage
- Add CSS classes for custom font families
- Maintain zero-jiggle ORP alignment with all monospace fonts

All fonts are loaded lazily only when selected, improving initial page load.
The system is extensible - new fonts can be added to fontConfig.ts.

https://claude.ai/code/session_012oDnk5pKiBmBGCFbrhCVHh