### PR TITLE
feat: add trade-journal CLI app

### DIFF
--- a/apps/trade-journal/.gitignore
+++ b/apps/trade-journal/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+*.db
+*.db-journal
+*.db-wal
+*.db-shm
+.env

--- a/apps/trade-journal/README.md
+++ b/apps/trade-journal/README.md
@@ -1,0 +1,160 @@
+# Trade Journal CLI
+
+A local-first trading journal CLI for logging trades, calculating statistics, and generating reports.
+
+## Features
+
+- 📝 **Manual Trade Logging** - Log trades with entry/exit prices, quantities, and more
+- 📥 **Import from ThinkorSwim** - Parse and import trades from TD Ameritrade/Schwab CSV exports
+- 📊 **Statistics** - Win rate, P&L, profit factor, R:R ratio, streaks, and more
+- 📈 **HTML Reports** - Generate beautiful HTML reports for any time period
+- 🔒 **Local-first** - All data stored locally in SQLite - your data stays on your machine
+
+## Installation
+
+```bash
+# From the monorepo root
+pnpm install
+pnpm --filter @hudak/trade-journal build
+
+# Add to PATH (optional)
+npm link ./apps/trade-journal
+```
+
+## Usage
+
+### Log a Trade
+
+```bash
+# Log a closed trade
+trade log TSLA --side long --entry 280.50 --exit 285.00 --shares 100
+
+# Log an open position with risk levels
+trade log SPY --side short --entry 450.00 --shares 100 --stop 455 --target 440
+
+# Log with notes and strategy
+trade log AAPL --side long --entry 175 --exit 180 --shares 50 \
+  --strategy "gap-and-go" --notes "Strong pre-market volume"
+```
+
+### Import from ThinkorSwim
+
+```bash
+# Import trades from ThinkorSwim CSV export
+trade import ~/Downloads/tos-trades.csv
+
+# Preview import without saving
+trade import trades.csv --dry-run
+```
+
+### View Statistics
+
+```bash
+# All-time stats
+trade stats
+
+# Weekly stats with symbol breakdown
+trade stats --period week --by-symbol
+
+# Monthly stats with daily breakdown
+trade stats --period month --daily
+
+# Custom date range
+trade stats --from 2024-01-01 --to 2024-01-31
+```
+
+### Generate Reports
+
+```bash
+# Generate report for current month
+trade report
+
+# Generate report for specific month
+trade report --month january --year 2024
+
+# Generate and open in browser
+trade report --month january --open
+
+# Custom date range
+trade report --from 2024-01-01 --to 2024-03-31 --output q1-report.html
+```
+
+### List Trades
+
+```bash
+# List recent trades
+trade list
+
+# Filter by symbol
+trade list --symbol TSLA
+
+# Filter by status
+trade list --status open
+
+# Combine filters
+trade list --symbol TSLA --side long --limit 50
+```
+
+## Statistics Tracked
+
+| Metric | Description |
+|--------|-------------|
+| Win Rate | Percentage of winning trades |
+| Total P&L | Net profit/loss |
+| Gross Profit | Sum of all winning trades |
+| Gross Loss | Sum of all losing trades |
+| Profit Factor | Gross Profit / Gross Loss |
+| Expectancy | Average P&L per trade |
+| Average Win | Mean winning trade value |
+| Average Loss | Mean losing trade value |
+| Largest Win | Biggest single winner |
+| Largest Loss | Biggest single loser |
+| R:R Ratio | Average risk/reward ratio |
+| Win/Lose Streak | Current and longest streaks |
+
+## ThinkorSwim Import
+
+The CLI supports importing trades from ThinkorSwim CSV exports. To export from ToS:
+
+1. Open thinkorswim
+2. Go to **Monitor** → **Account Statement**
+3. Select the date range
+4. Click **Export to File** (CSV format)
+
+The importer will:
+- Parse execution times, symbols, quantities, and prices
+- Detect if trades are opening or closing positions
+- Match entries with exits using FIFO (First In, First Out)
+- Calculate P&L for matched trades
+- Skip duplicate imports
+
+## Data Storage
+
+All data is stored locally in SQLite at:
+- **macOS/Linux**: `~/.local/share/trade-journal/trades.db`
+- **Custom**: Set `TRADE_JOURNAL_DATA_DIR` environment variable
+
+## Development
+
+```bash
+# Watch mode
+pnpm dev
+
+# Run tests
+pnpm test
+
+# Type checking
+pnpm typecheck
+
+# Build
+pnpm build
+```
+
+## Inspired By
+
+- [TradeNote](https://github.com/Eleven-Trading/TradeNote) - Web-based trading journal
+- [Deltalytix](https://github.com/hugodemenez/deltalytix) - Trading analytics platform
+
+## License
+
+ISC

--- a/apps/trade-journal/package.json
+++ b/apps/trade-journal/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@hudak/trade-journal",
+  "version": "1.0.0",
+  "description": "Trade journal CLI - Log trades, calculate statistics, and generate reports",
+  "type": "module",
+  "bin": {
+    "trade": "./dist/cli.js"
+  },
+  "scripts": {
+    "dev": "tsup --watch",
+    "build": "tsup",
+    "typecheck": "tsc --noEmit",
+    "lint": "eslint src --ext ts --report-unused-disable-directives --max-warnings 0",
+    "clean": "rm -rf dist node_modules",
+    "trade": "node dist/cli.js",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "keywords": [
+    "trading",
+    "journal",
+    "cli",
+    "stocks",
+    "options",
+    "analytics"
+  ],
+  "author": "Jonathan Hudak",
+  "license": "ISC",
+  "dependencies": {
+    "better-sqlite3": "^11.6.0",
+    "chalk": "^5.3.0",
+    "cli-table3": "^0.6.5",
+    "commander": "^12.1.0",
+    "csv-parse": "^5.6.0",
+    "date-fns": "^4.1.0",
+    "handlebars": "^4.7.8",
+    "nanoid": "^5.0.9",
+    "open": "^10.1.0",
+    "ora": "^8.1.0"
+  },
+  "devDependencies": {
+    "@tools/eslint-config": "workspace:*",
+    "@tools/typescript-config": "workspace:*",
+    "@types/better-sqlite3": "^7.6.12",
+    "tsup": "^8.3.5",
+    "typescript": "^5.9.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/trade-journal/src/__tests__/database.test.ts
+++ b/apps/trade-journal/src/__tests__/database.test.ts
@@ -1,0 +1,229 @@
+// Database tests
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import Database from 'better-sqlite3';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { unlinkSync, existsSync } from 'fs';
+import {
+  getDatabase,
+  closeDatabase,
+  insertTrade,
+  getTrade,
+  getTrades,
+  calculateStats,
+  calculatePnL,
+} from '../core/database.js';
+
+describe('Database', () => {
+  const testDbPath = join(tmpdir(), `trade-journal-test-${Date.now()}.db`);
+
+  afterEach(() => {
+    closeDatabase();
+    if (existsSync(testDbPath)) {
+      try {
+        unlinkSync(testDbPath);
+        unlinkSync(testDbPath + '-wal');
+        unlinkSync(testDbPath + '-shm');
+      } catch {}
+    }
+  });
+
+  describe('insertTrade', () => {
+    it('should insert a trade and return it with an id', () => {
+      const db = getDatabase(testDbPath);
+
+      const trade = insertTrade(db, {
+        symbol: 'TSLA',
+        side: 'long',
+        assetType: 'stock',
+        status: 'closed',
+        entryPrice: 280.50,
+        entryDate: new Date('2024-01-15'),
+        entryQuantity: 100,
+        exitPrice: 285.00,
+        exitDate: new Date('2024-01-16'),
+        exitQuantity: 100,
+        pnl: 450,
+        pnlPercent: 1.6,
+        stopLoss: 275,
+        takeProfit: 290,
+        riskRewardRatio: 1.72,
+        commission: 0,
+        fees: 0,
+        notes: 'Test trade',
+        strategy: 'momentum',
+        tags: ['test'],
+        importHash: null,
+        importSource: 'manual',
+      });
+
+      expect(trade.id).toBeDefined();
+      expect(trade.symbol).toBe('TSLA');
+      expect(trade.pnl).toBe(450);
+    });
+
+    it('should retrieve a trade by id', () => {
+      const db = getDatabase(testDbPath);
+
+      const inserted = insertTrade(db, {
+        symbol: 'AAPL',
+        side: 'short',
+        assetType: 'stock',
+        status: 'open',
+        entryPrice: 180,
+        entryDate: new Date('2024-01-20'),
+        entryQuantity: 50,
+        exitPrice: null,
+        exitDate: null,
+        exitQuantity: null,
+        pnl: null,
+        pnlPercent: null,
+        stopLoss: 185,
+        takeProfit: 170,
+        riskRewardRatio: 2,
+        commission: 0,
+        fees: 0,
+        notes: null,
+        strategy: null,
+        tags: [],
+        importHash: null,
+        importSource: 'manual',
+      });
+
+      const retrieved = getTrade(db, inserted.id);
+      expect(retrieved).not.toBeNull();
+      expect(retrieved!.symbol).toBe('AAPL');
+      expect(retrieved!.side).toBe('short');
+      expect(retrieved!.status).toBe('open');
+    });
+  });
+
+  describe('getTrades', () => {
+    it('should filter trades by symbol', () => {
+      const db = getDatabase(testDbPath);
+
+      // Insert multiple trades
+      insertTrade(db, createTestTrade({ symbol: 'TSLA' }));
+      insertTrade(db, createTestTrade({ symbol: 'AAPL' }));
+      insertTrade(db, createTestTrade({ symbol: 'TSLA' }));
+
+      const tslaTrades = getTrades(db, { symbol: 'TSLA' });
+      expect(tslaTrades.length).toBe(2);
+      expect(tslaTrades.every(t => t.symbol === 'TSLA')).toBe(true);
+    });
+
+    it('should filter trades by status', () => {
+      const db = getDatabase(testDbPath);
+
+      insertTrade(db, createTestTrade({ status: 'open' }));
+      insertTrade(db, createTestTrade({ status: 'closed' }));
+      insertTrade(db, createTestTrade({ status: 'closed' }));
+
+      const openTrades = getTrades(db, { status: 'open' });
+      expect(openTrades.length).toBe(1);
+
+      const closedTrades = getTrades(db, { status: 'closed' });
+      expect(closedTrades.length).toBe(2);
+    });
+  });
+
+  describe('calculateStats', () => {
+    it('should calculate correct win rate', () => {
+      const db = getDatabase(testDbPath);
+
+      // 3 wins, 2 losses = 60% win rate
+      insertTrade(db, createTestTrade({ pnl: 100, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: 50, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: 200, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: -75, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: -25, status: 'closed' }));
+
+      const stats = calculateStats(db);
+
+      expect(stats.totalTrades).toBe(5);
+      expect(stats.winningTrades).toBe(3);
+      expect(stats.losingTrades).toBe(2);
+      expect(stats.winRate).toBe(60);
+    });
+
+    it('should calculate correct P&L totals', () => {
+      const db = getDatabase(testDbPath);
+
+      insertTrade(db, createTestTrade({ pnl: 100, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: -50, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: 75, status: 'closed' }));
+
+      const stats = calculateStats(db);
+
+      expect(stats.grossProfit).toBe(175);
+      expect(stats.grossLoss).toBe(50);
+      expect(stats.totalPnl).toBe(125);
+    });
+
+    it('should calculate profit factor correctly', () => {
+      const db = getDatabase(testDbPath);
+
+      insertTrade(db, createTestTrade({ pnl: 200, status: 'closed' }));
+      insertTrade(db, createTestTrade({ pnl: -100, status: 'closed' }));
+
+      const stats = calculateStats(db);
+
+      expect(stats.profitFactor).toBe(2); // 200 / 100
+    });
+  });
+
+  describe('calculatePnL', () => {
+    it('should calculate long trade P&L correctly', () => {
+      const result = calculatePnL('long', 100, 110, 10);
+      expect(result.pnl).toBe(100); // (110 - 100) * 10
+      expect(result.pnlPercent).toBeCloseTo(10); // 10%
+    });
+
+    it('should calculate short trade P&L correctly', () => {
+      const result = calculatePnL('short', 100, 90, 10);
+      expect(result.pnl).toBe(100); // (100 - 90) * 10
+      expect(result.pnlPercent).toBeCloseTo(10);
+    });
+
+    it('should subtract commissions and fees', () => {
+      const result = calculatePnL('long', 100, 110, 10, 5, 3);
+      expect(result.pnl).toBe(92); // 100 - 5 - 3
+    });
+
+    it('should calculate losing long trade correctly', () => {
+      const result = calculatePnL('long', 100, 95, 10);
+      expect(result.pnl).toBe(-50); // (95 - 100) * 10
+      expect(result.pnlPercent).toBeCloseTo(-5);
+    });
+  });
+});
+
+// Helper to create test trades
+function createTestTrade(overrides: Partial<Parameters<typeof insertTrade>[1]> = {}) {
+  return {
+    symbol: 'TEST',
+    side: 'long' as const,
+    assetType: 'stock' as const,
+    status: 'closed' as const,
+    entryPrice: 100,
+    entryDate: new Date(),
+    entryQuantity: 10,
+    exitPrice: 105,
+    exitDate: new Date(),
+    exitQuantity: 10,
+    pnl: 50,
+    pnlPercent: 5,
+    stopLoss: null,
+    takeProfit: null,
+    riskRewardRatio: null,
+    commission: 0,
+    fees: 0,
+    notes: null,
+    strategy: null,
+    tags: [],
+    importHash: null,
+    importSource: 'test',
+    ...overrides,
+  };
+}

--- a/apps/trade-journal/src/__tests__/tos-parser.test.ts
+++ b/apps/trade-journal/src/__tests__/tos-parser.test.ts
@@ -1,0 +1,77 @@
+// ThinkorSwim parser tests
+
+import { describe, it, expect } from 'vitest';
+import { generateImportHash, groupTradesBySymbol, type ParsedToSTrade } from '../import/tos-parser.js';
+
+describe('ToS Parser', () => {
+  describe('generateImportHash', () => {
+    it('should generate consistent hashes for same input', () => {
+      const date = new Date('2024-01-15T10:30:00');
+      const hash1 = generateImportHash(date, 'TSLA', 'long', 280.50, 100);
+      const hash2 = generateImportHash(date, 'TSLA', 'long', 280.50, 100);
+      
+      expect(hash1).toBe(hash2);
+    });
+
+    it('should generate different hashes for different inputs', () => {
+      const date = new Date('2024-01-15T10:30:00');
+      const hash1 = generateImportHash(date, 'TSLA', 'long', 280.50, 100);
+      const hash2 = generateImportHash(date, 'AAPL', 'long', 280.50, 100);
+      
+      expect(hash1).not.toBe(hash2);
+    });
+  });
+
+  describe('groupTradesBySymbol', () => {
+    it('should group trades by symbol', () => {
+      const trades: ParsedToSTrade[] = [
+        createParsedTrade({ symbol: 'TSLA', isOpening: true }),
+        createParsedTrade({ symbol: 'AAPL', isOpening: true }),
+        createParsedTrade({ symbol: 'TSLA', isOpening: false }),
+        createParsedTrade({ symbol: 'TSLA', isOpening: true }),
+      ];
+
+      const grouped = groupTradesBySymbol(trades);
+
+      expect(grouped.length).toBe(2);
+      
+      const tslaGroup = grouped.find(g => g.symbol === 'TSLA');
+      expect(tslaGroup?.entries.length).toBe(2);
+      expect(tslaGroup?.exits.length).toBe(1);
+
+      const aaplGroup = grouped.find(g => g.symbol === 'AAPL');
+      expect(aaplGroup?.entries.length).toBe(1);
+      expect(aaplGroup?.exits.length).toBe(0);
+    });
+
+    it('should separate entries and exits', () => {
+      const trades: ParsedToSTrade[] = [
+        createParsedTrade({ symbol: 'SPY', isOpening: true }),
+        createParsedTrade({ symbol: 'SPY', isOpening: false }),
+        createParsedTrade({ symbol: 'SPY', isOpening: false }),
+      ];
+
+      const grouped = groupTradesBySymbol(trades);
+      const spyGroup = grouped[0];
+
+      expect(spyGroup.entries.length).toBe(1);
+      expect(spyGroup.exits.length).toBe(2);
+    });
+  });
+});
+
+// Helper to create test parsed trades
+function createParsedTrade(overrides: Partial<ParsedToSTrade> = {}): ParsedToSTrade {
+  return {
+    execTime: new Date(),
+    symbol: 'TEST',
+    side: 'long',
+    assetType: 'stock',
+    quantity: 100,
+    price: 100,
+    netPrice: 100,
+    isOpening: true,
+    rawRow: {},
+    ...overrides,
+  };
+}

--- a/apps/trade-journal/src/cli.ts
+++ b/apps/trade-journal/src/cli.ts
@@ -1,0 +1,90 @@
+// Trade Journal CLI
+// A local-first trading journal with statistics and reporting
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { createLogCommand } from './commands/log.js';
+import { createImportCommand } from './commands/import.js';
+import { createStatsCommand } from './commands/stats.js';
+import { createReportCommand } from './commands/report.js';
+import { createListCommand } from './commands/list.js';
+import { closeDatabase } from './core/database.js';
+
+const program = new Command();
+
+program
+  .name('trade')
+  .description('Trade Journal - Log trades, track statistics, generate reports')
+  .version('1.0.0')
+  .hook('postAction', () => {
+    closeDatabase();
+  });
+
+// Add commands
+program.addCommand(createLogCommand());
+program.addCommand(createImportCommand());
+program.addCommand(createStatsCommand());
+program.addCommand(createReportCommand());
+program.addCommand(createListCommand());
+
+// Default action - show help
+program.action(() => {
+  console.log(chalk.bold.cyan(`
+  ╔═══════════════════════════════════════════════════════════╗
+  ║               Trade Journal CLI v1.0.0                    ║
+  ║       Log trades • Track stats • Generate reports         ║
+  ╚═══════════════════════════════════════════════════════════╝
+`));
+
+  console.log(chalk.bold('Quick Start:'));
+  console.log(`
+  1. Log a trade:    ${chalk.cyan('trade log TSLA --side long --entry 280.50 --exit 285.00 --shares 100')}
+  2. Import trades:  ${chalk.cyan('trade import ~/Downloads/tos-trades.csv')}
+  3. View stats:     ${chalk.cyan('trade stats --period week')}
+  4. Generate report: ${chalk.cyan('trade report --month january --open')}
+`);
+
+  console.log(chalk.bold('Commands:'));
+  console.log(`
+  ${chalk.cyan('log')} <symbol>      Log a new trade manually
+  ${chalk.cyan('import')} <file>     Import trades from CSV (ThinkorSwim)
+  ${chalk.cyan('list')}              View logged trades
+  ${chalk.cyan('stats')}             Display trading statistics
+  ${chalk.cyan('report')}            Generate HTML report
+`);
+
+  console.log(chalk.bold('Examples:'));
+  console.log(`
+  ${chalk.dim('# Log a closed long trade with profit')}
+  ${chalk.cyan('trade log AAPL --side long --entry 175.50 --exit 182.00 --shares 50')}
+
+  ${chalk.dim('# Log an open short position')}
+  ${chalk.cyan('trade log SPY --side short --entry 450.00 --shares 100 --stop 455 --target 440')}
+
+  ${chalk.dim('# Import ThinkorSwim trades')}
+  ${chalk.cyan('trade import ./trades.csv --format tos')}
+
+  ${chalk.dim('# View weekly stats with symbol breakdown')}
+  ${chalk.cyan('trade stats --period week --by-symbol')}
+
+  ${chalk.dim('# Generate January report and open in browser')}
+  ${chalk.cyan('trade report --month january --open')}
+`);
+
+  console.log(chalk.dim('Run "trade <command> --help" for detailed usage.\n'));
+});
+
+// Error handling
+program.exitOverride((err) => {
+  if (err.code === 'commander.helpDisplayed') {
+    process.exit(0);
+  }
+  if (err.code === 'commander.version') {
+    process.exit(0);
+  }
+  console.error(chalk.red(err.message));
+  process.exit(1);
+});
+
+// Parse arguments
+program.parse();

--- a/apps/trade-journal/src/commands/import.ts
+++ b/apps/trade-journal/src/commands/import.ts
@@ -1,0 +1,282 @@
+// Import command - import trades from CSV files
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import path from 'path';
+import fs from 'fs';
+import {
+  getDatabase,
+  insertTrade,
+  tradeExists,
+  createImport,
+  calculatePnL,
+} from '../core/database.js';
+import { getDatabasePath, ensureDataDir } from '../core/config.js';
+import {
+  parseToSCSV,
+  generateImportHash,
+  groupTradesBySymbol,
+  type ParsedToSTrade,
+} from '../import/tos-parser.js';
+
+export function createImportCommand(): Command {
+  const cmd = new Command('import')
+    .description('Import trades from a CSV file')
+    .argument('<file>', 'Path to the CSV file')
+    .option('-f, --format <format>', 'CSV format: tos (ThinkorSwim)', 'tos')
+    .option('--dry-run', 'Preview import without saving')
+    .option('--match-trades', 'Attempt to match entries with exits', true)
+    .action(async (file: string, options) => {
+      await runImport(file, options);
+    });
+
+  return cmd;
+}
+
+async function runImport(
+  file: string,
+  options: {
+    format: string;
+    dryRun?: boolean;
+    matchTrades?: boolean;
+  }
+): Promise<void> {
+  // Check file exists
+  const filePath = path.resolve(file);
+  if (!fs.existsSync(filePath)) {
+    console.error(chalk.red(`Error: File not found: ${filePath}`));
+    process.exit(1);
+  }
+
+  const spinner = ora('Parsing CSV file...').start();
+
+  // Parse based on format
+  let parseResult;
+  if (options.format.toLowerCase() === 'tos') {
+    parseResult = parseToSCSV(filePath);
+  } else {
+    spinner.fail('Unknown format');
+    console.error(chalk.red(`Error: Unknown format "${options.format}". Supported: tos`));
+    process.exit(1);
+  }
+
+  if (parseResult.errors.length > 0 && parseResult.trades.length === 0) {
+    spinner.fail('Failed to parse CSV');
+    for (const error of parseResult.errors) {
+      console.error(chalk.red(`  ${error}`));
+    }
+    process.exit(1);
+  }
+
+  spinner.succeed(
+    `Parsed ${parseResult.trades.length} trade records from ${parseResult.totalRows} rows`
+  );
+
+  if (parseResult.errors.length > 0) {
+    console.log(chalk.yellow(`\nWarnings (${parseResult.errors.length}):`));
+    for (const error of parseResult.errors.slice(0, 5)) {
+      console.log(chalk.yellow(`  ${error}`));
+    }
+    if (parseResult.errors.length > 5) {
+      console.log(chalk.yellow(`  ... and ${parseResult.errors.length - 5} more`));
+    }
+  }
+
+  if (parseResult.trades.length === 0) {
+    console.log(chalk.yellow('\nNo trades to import.'));
+    return;
+  }
+
+  // Group by symbol to match entries with exits
+  const grouped = groupTradesBySymbol(parseResult.trades);
+  
+  console.log(chalk.bold('\nTrade Summary by Symbol:'));
+  console.log('─'.repeat(60));
+  
+  for (const group of grouped.slice(0, 10)) {
+    const entries = group.entries.length;
+    const exits = group.exits.length;
+    console.log(
+      `  ${chalk.cyan(group.symbol.padEnd(10))} ` +
+      `${chalk.green(`${entries} entries`)} / ${chalk.red(`${exits} exits`)}`
+    );
+  }
+  
+  if (grouped.length > 10) {
+    console.log(chalk.dim(`  ... and ${grouped.length - 10} more symbols`));
+  }
+  console.log('─'.repeat(60));
+
+  // Dry run stops here
+  if (options.dryRun) {
+    console.log(chalk.cyan('\nDry run complete. No changes made.'));
+    return;
+  }
+
+  // Initialize database
+  ensureDataDir();
+  const db = getDatabase(getDatabasePath());
+
+  const importSpinner = ora('Importing trades...').start();
+
+  let imported = 0;
+  let skipped = 0;
+  let matched = 0;
+
+  // Process each group - try to match entries with exits
+  for (const group of grouped) {
+    const { entries, exits } = group;
+    
+    // Sort by time
+    entries.sort((a, b) => a.execTime.getTime() - b.execTime.getTime());
+    exits.sort((a, b) => a.execTime.getTime() - b.execTime.getTime());
+
+    // FIFO matching: match oldest entry with oldest exit
+    const usedExits = new Set<number>();
+
+    for (const entry of entries) {
+      const importHash = generateImportHash(
+        entry.execTime,
+        entry.symbol,
+        entry.side,
+        entry.price,
+        entry.quantity
+      );
+
+      if (tradeExists(db, importHash)) {
+        skipped++;
+        continue;
+      }
+
+      // Try to find matching exit
+      let matchedExit: ParsedToSTrade | null = null;
+      let matchedExitIdx = -1;
+
+      if (options.matchTrades) {
+        for (let i = 0; i < exits.length; i++) {
+          if (usedExits.has(i)) continue;
+          
+          const exit = exits[i];
+          // Exit must be after entry and same quantity
+          if (
+            exit.execTime > entry.execTime &&
+            exit.quantity === entry.quantity
+          ) {
+            matchedExit = exit;
+            matchedExitIdx = i;
+            break;
+          }
+        }
+      }
+
+      // Calculate P&L if we have an exit
+      let pnl: number | null = null;
+      let pnlPercent: number | null = null;
+      
+      if (matchedExit) {
+        usedExits.add(matchedExitIdx);
+        const result = calculatePnL(
+          entry.side,
+          entry.price,
+          matchedExit.price,
+          entry.quantity
+        );
+        pnl = result.pnl;
+        pnlPercent = result.pnlPercent;
+        matched++;
+      }
+
+      // Insert trade
+      insertTrade(db, {
+        symbol: entry.symbol,
+        side: entry.side,
+        assetType: entry.assetType,
+        status: matchedExit ? 'closed' : 'open',
+        entryPrice: entry.price,
+        entryDate: entry.execTime,
+        entryQuantity: entry.quantity,
+        exitPrice: matchedExit?.price ?? null,
+        exitDate: matchedExit?.execTime ?? null,
+        exitQuantity: matchedExit?.quantity ?? null,
+        pnl,
+        pnlPercent,
+        stopLoss: null,
+        takeProfit: null,
+        riskRewardRatio: null,
+        commission: 0,
+        fees: 0,
+        notes: null,
+        strategy: null,
+        tags: [],
+        importHash,
+        importSource: 'tos',
+      });
+
+      imported++;
+    }
+
+    // Also import unmatched exits as standalone (closing) trades
+    for (let i = 0; i < exits.length; i++) {
+      if (usedExits.has(i)) continue;
+      
+      const exit = exits[i];
+      const importHash = generateImportHash(
+        exit.execTime,
+        exit.symbol,
+        'close-' + exit.side,
+        exit.price,
+        exit.quantity
+      );
+
+      if (tradeExists(db, importHash)) {
+        skipped++;
+        continue;
+      }
+
+      // Create as a closed trade (we don't know the entry)
+      insertTrade(db, {
+        symbol: exit.symbol,
+        side: exit.side,
+        assetType: exit.assetType,
+        status: 'closed',
+        entryPrice: exit.price, // Use exit price as entry (unknown entry)
+        entryDate: exit.execTime,
+        entryQuantity: exit.quantity,
+        exitPrice: exit.price,
+        exitDate: exit.execTime,
+        exitQuantity: exit.quantity,
+        pnl: 0, // Unknown P&L
+        pnlPercent: 0,
+        stopLoss: null,
+        takeProfit: null,
+        riskRewardRatio: null,
+        commission: 0,
+        fees: 0,
+        notes: 'Exit only - entry not found',
+        strategy: null,
+        tags: ['unmatched-exit'],
+        importHash,
+        importSource: 'tos',
+      });
+
+      imported++;
+    }
+  }
+
+  // Record import
+  createImport(db, {
+    filename: path.basename(filePath),
+    source: options.format,
+    rowCount: parseResult.totalRows,
+    importedCount: imported,
+    skippedCount: skipped,
+  });
+
+  importSpinner.succeed(
+    `Imported ${imported} trades (${matched} matched, ${skipped} duplicates skipped)`
+  );
+
+  console.log(chalk.green(`\n✓ Import complete!`));
+  console.log(chalk.dim(`Run 'trade stats' to see your trading statistics.\n`));
+}

--- a/apps/trade-journal/src/commands/list.ts
+++ b/apps/trade-journal/src/commands/list.ts
@@ -1,0 +1,88 @@
+// List command - view trades
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import { format } from 'date-fns';
+import { getDatabase, getTrades } from '../core/database.js';
+import { getDatabasePath, ensureDataDir } from '../core/config.js';
+
+export function createListCommand(): Command {
+  const cmd = new Command('list')
+    .description('List trades')
+    .option('-s, --symbol <symbol>', 'Filter by symbol')
+    .option('--side <side>', 'Filter by side: long or short')
+    .option('--status <status>', 'Filter by status: open or closed', 'all')
+    .option('-n, --limit <n>', 'Number of trades to show', '20')
+    .option('--from <date>', 'Start date (YYYY-MM-DD)')
+    .option('--to <date>', 'End date (YYYY-MM-DD)')
+    .action(async (options) => {
+      await listTrades(options);
+    });
+
+  return cmd;
+}
+
+async function listTrades(options: {
+  symbol?: string;
+  side?: string;
+  status: string;
+  limit: string;
+  from?: string;
+  to?: string;
+}): Promise<void> {
+  ensureDataDir();
+  const db = getDatabase(getDatabasePath());
+
+  const trades = getTrades(db, {
+    symbol: options.symbol?.toUpperCase(),
+    side: options.side as 'long' | 'short' | undefined,
+    status: options.status === 'all' ? undefined : options.status as 'open' | 'closed',
+    from: options.from ? new Date(options.from) : undefined,
+    to: options.to ? new Date(options.to) : undefined,
+    limit: parseInt(options.limit),
+  });
+
+  if (trades.length === 0) {
+    console.log(chalk.yellow('\nNo trades found matching criteria.'));
+    console.log(chalk.dim('Log trades with: trade log TSLA --side long --entry 280 --exit 285 --shares 100\n'));
+    return;
+  }
+
+  console.log(chalk.bold(`\n📋 Trades (${trades.length}):\n`));
+
+  const table = new Table({
+    head: [
+      chalk.bold('Date'),
+      chalk.bold('Symbol'),
+      chalk.bold('Side'),
+      chalk.bold('Status'),
+      chalk.bold('Entry'),
+      chalk.bold('Exit'),
+      chalk.bold('Qty'),
+      chalk.bold('P&L'),
+    ],
+    colAligns: ['left', 'left', 'left', 'left', 'right', 'right', 'right', 'right'],
+  });
+
+  for (const trade of trades) {
+    const sideColor = trade.side === 'long' ? chalk.green : chalk.red;
+    const statusColor = trade.status === 'open' ? chalk.yellow : chalk.gray;
+    const pnl = trade.pnl ?? 0;
+    const pnlColor = pnl >= 0 ? chalk.green : chalk.red;
+
+    table.push([
+      format(trade.entryDate, 'yyyy-MM-dd'),
+      chalk.cyan(trade.symbol),
+      sideColor(trade.side.toUpperCase()),
+      statusColor(trade.status.toUpperCase()),
+      `$${trade.entryPrice.toFixed(2)}`,
+      trade.exitPrice ? `$${trade.exitPrice.toFixed(2)}` : chalk.dim('-'),
+      trade.entryQuantity.toString(),
+      trade.status === 'closed' ? pnlColor(`$${pnl.toFixed(2)}`) : chalk.dim('-'),
+    ]);
+  }
+
+  console.log(table.toString());
+  console.log();
+}

--- a/apps/trade-journal/src/commands/log.ts
+++ b/apps/trade-journal/src/commands/log.ts
@@ -1,0 +1,203 @@
+// Log command - manually log a trade
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import {
+  getDatabase,
+  insertTrade,
+  updateTrade,
+  getTrade,
+  calculatePnL,
+} from '../core/database.js';
+import { getDatabasePath, ensureDataDir } from '../core/config.js';
+import type { Trade } from '../core/types.js';
+
+export function createLogCommand(): Command {
+  const cmd = new Command('log')
+    .description('Log a new trade')
+    .argument('<symbol>', 'Stock/option symbol (e.g., TSLA, AAPL)')
+    .option('-s, --side <side>', 'Trade side: long or short', 'long')
+    .option('-e, --entry <price>', 'Entry price')
+    .option('-x, --exit <price>', 'Exit price (creates closed trade)')
+    .option('-q, --shares <quantity>', 'Number of shares/contracts', '1')
+    .option('-d, --date <date>', 'Entry date (YYYY-MM-DD)', new Date().toISOString().split('T')[0])
+    .option('--exit-date <date>', 'Exit date (YYYY-MM-DD)')
+    .option('-t, --type <type>', 'Asset type: stock, option, futures, forex, crypto', 'stock')
+    .option('--stop <price>', 'Stop loss price')
+    .option('--target <price>', 'Take profit target price')
+    .option('-c, --commission <amount>', 'Commission paid', '0')
+    .option('-f, --fees <amount>', 'Other fees', '0')
+    .option('-n, --notes <text>', 'Trade notes')
+    .option('--strategy <name>', 'Strategy name')
+    .option('--tags <tags>', 'Comma-separated tags')
+    .action(async (symbol: string, options) => {
+      await logTrade(symbol.toUpperCase(), options);
+    });
+
+  return cmd;
+}
+
+async function logTrade(
+  symbol: string,
+  options: {
+    side: string;
+    entry?: string;
+    exit?: string;
+    shares: string;
+    date: string;
+    exitDate?: string;
+    type: string;
+    stop?: string;
+    target?: string;
+    commission: string;
+    fees: string;
+    notes?: string;
+    strategy?: string;
+    tags?: string;
+  }
+): Promise<void> {
+  // Validate side
+  const side = options.side.toLowerCase();
+  if (side !== 'long' && side !== 'short') {
+    console.error(chalk.red('Error: Side must be "long" or "short"'));
+    process.exit(1);
+  }
+
+  // Validate and parse entry price
+  if (!options.entry) {
+    console.error(chalk.red('Error: Entry price is required (--entry <price>)'));
+    process.exit(1);
+  }
+
+  const entryPrice = parseFloat(options.entry);
+  if (isNaN(entryPrice) || entryPrice <= 0) {
+    console.error(chalk.red('Error: Invalid entry price'));
+    process.exit(1);
+  }
+
+  // Parse quantity
+  const quantity = parseFloat(options.shares);
+  if (isNaN(quantity) || quantity <= 0) {
+    console.error(chalk.red('Error: Invalid share quantity'));
+    process.exit(1);
+  }
+
+  // Parse dates
+  const entryDate = new Date(options.date);
+  if (isNaN(entryDate.getTime())) {
+    console.error(chalk.red('Error: Invalid entry date'));
+    process.exit(1);
+  }
+
+  // Parse optional exit
+  let exitPrice: number | null = null;
+  let exitDate: Date | null = null;
+  let status: 'open' | 'closed' = 'open';
+  let pnl: number | null = null;
+  let pnlPercent: number | null = null;
+
+  if (options.exit) {
+    exitPrice = parseFloat(options.exit);
+    if (isNaN(exitPrice) || exitPrice <= 0) {
+      console.error(chalk.red('Error: Invalid exit price'));
+      process.exit(1);
+    }
+    status = 'closed';
+    exitDate = options.exitDate ? new Date(options.exitDate) : new Date();
+    
+    // Calculate P&L
+    const result = calculatePnL(
+      side as 'long' | 'short',
+      entryPrice,
+      exitPrice,
+      quantity,
+      parseFloat(options.commission),
+      parseFloat(options.fees)
+    );
+    pnl = result.pnl;
+    pnlPercent = result.pnlPercent;
+  }
+
+  // Parse optional prices
+  const stopLoss = options.stop ? parseFloat(options.stop) : null;
+  const takeProfit = options.target ? parseFloat(options.target) : null;
+
+  // Calculate risk/reward if we have stop and target
+  let riskRewardRatio: number | null = null;
+  if (stopLoss && takeProfit) {
+    if (side === 'long') {
+      const risk = entryPrice - stopLoss;
+      const reward = takeProfit - entryPrice;
+      riskRewardRatio = risk > 0 ? reward / risk : null;
+    } else {
+      const risk = stopLoss - entryPrice;
+      const reward = entryPrice - takeProfit;
+      riskRewardRatio = risk > 0 ? reward / risk : null;
+    }
+  }
+
+  // Parse tags
+  const tags = options.tags ? options.tags.split(',').map(t => t.trim()) : [];
+
+  // Initialize database
+  ensureDataDir();
+  const db = getDatabase(getDatabasePath());
+
+  // Create trade
+  const trade = insertTrade(db, {
+    symbol,
+    side: side as 'long' | 'short',
+    assetType: options.type as Trade['assetType'],
+    status,
+    entryPrice,
+    entryDate,
+    entryQuantity: quantity,
+    exitPrice,
+    exitDate,
+    exitQuantity: exitPrice ? quantity : null,
+    pnl,
+    pnlPercent,
+    stopLoss,
+    takeProfit,
+    riskRewardRatio,
+    commission: parseFloat(options.commission),
+    fees: parseFloat(options.fees),
+    notes: options.notes ?? null,
+    strategy: options.strategy ?? null,
+    tags,
+    importHash: null,
+    importSource: 'manual',
+  });
+
+  // Display result
+  console.log(chalk.bold.green('\n✓ Trade logged successfully!\n'));
+
+  const sideColor = side === 'long' ? chalk.green : chalk.red;
+  const pnlColor = pnl !== null && pnl >= 0 ? chalk.green : chalk.red;
+
+  console.log(`  ${chalk.bold('ID:')}        ${trade.id}`);
+  console.log(`  ${chalk.bold('Symbol:')}    ${chalk.cyan(symbol)}`);
+  console.log(`  ${chalk.bold('Side:')}      ${sideColor(side.toUpperCase())}`);
+  console.log(`  ${chalk.bold('Entry:')}     $${entryPrice.toFixed(2)} × ${quantity} shares`);
+  console.log(`  ${chalk.bold('Date:')}      ${entryDate.toISOString().split('T')[0]}`);
+
+  if (exitPrice !== null) {
+    console.log(`  ${chalk.bold('Exit:')}      $${exitPrice.toFixed(2)}`);
+    console.log(`  ${chalk.bold('P&L:')}       ${pnlColor(`$${pnl!.toFixed(2)} (${pnlPercent!.toFixed(2)}%)`)}`);
+  }
+
+  if (stopLoss) {
+    console.log(`  ${chalk.bold('Stop:')}      $${stopLoss.toFixed(2)}`);
+  }
+  if (takeProfit) {
+    console.log(`  ${chalk.bold('Target:')}    $${takeProfit.toFixed(2)}`);
+  }
+  if (riskRewardRatio) {
+    console.log(`  ${chalk.bold('R:R:')}       1:${riskRewardRatio.toFixed(2)}`);
+  }
+  if (options.strategy) {
+    console.log(`  ${chalk.bold('Strategy:')} ${options.strategy}`);
+  }
+
+  console.log();
+}

--- a/apps/trade-journal/src/commands/report.ts
+++ b/apps/trade-journal/src/commands/report.ts
@@ -1,0 +1,392 @@
+// Report command - generate HTML reports
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import ora from 'ora';
+import fs from 'fs';
+import path from 'path';
+import Handlebars from 'handlebars';
+import open from 'open';
+import {
+  startOfMonth,
+  endOfMonth,
+  format,
+  parse,
+} from 'date-fns';
+import {
+  getDatabase,
+  calculateStats,
+  getSymbolStats,
+  getDailyStats,
+  getTrades,
+} from '../core/database.js';
+import { getDatabasePath, ensureDataDir, getReportsDir } from '../core/config.js';
+
+const MONTHS = [
+  'january', 'february', 'march', 'april', 'may', 'june',
+  'july', 'august', 'september', 'october', 'november', 'december'
+];
+
+export function createReportCommand(): Command {
+  const cmd = new Command('report')
+    .description('Generate an HTML report')
+    .option('-m, --month <month>', 'Month name or number (e.g., january or 1)')
+    .option('-y, --year <year>', 'Year (default: current year)')
+    .option('--from <date>', 'Start date (YYYY-MM-DD)')
+    .option('--to <date>', 'End date (YYYY-MM-DD)')
+    .option('-o, --output <file>', 'Output file path')
+    .option('--open', 'Open report in browser after generating')
+    .action(async (options) => {
+      await generateReport(options);
+    });
+
+  return cmd;
+}
+
+async function generateReport(options: {
+  month?: string;
+  year?: string;
+  from?: string;
+  to?: string;
+  output?: string;
+  open?: boolean;
+}): Promise<void> {
+  ensureDataDir();
+  const db = getDatabase(getDatabasePath());
+
+  // Determine date range
+  let from: Date;
+  let to: Date;
+  let periodLabel: string;
+
+  if (options.from && options.to) {
+    from = new Date(options.from);
+    to = new Date(options.to);
+    periodLabel = `${format(from, 'MMM d, yyyy')} - ${format(to, 'MMM d, yyyy')}`;
+  } else if (options.month) {
+    const year = parseInt(options.year || new Date().getFullYear().toString());
+    let monthNum: number;
+
+    // Parse month
+    const monthLower = options.month.toLowerCase();
+    if (MONTHS.includes(monthLower)) {
+      monthNum = MONTHS.indexOf(monthLower);
+    } else {
+      monthNum = parseInt(options.month) - 1;
+    }
+
+    if (isNaN(monthNum) || monthNum < 0 || monthNum > 11) {
+      console.error(chalk.red('Error: Invalid month. Use name (january) or number (1-12)'));
+      process.exit(1);
+    }
+
+    from = startOfMonth(new Date(year, monthNum));
+    to = endOfMonth(new Date(year, monthNum));
+    periodLabel = format(from, 'MMMM yyyy');
+  } else {
+    // Default to current month
+    from = startOfMonth(new Date());
+    to = endOfMonth(new Date());
+    periodLabel = format(from, 'MMMM yyyy');
+  }
+
+  const spinner = ora('Generating report...').start();
+
+  // Gather data
+  const stats = calculateStats(db, from, to);
+  const symbolStats = getSymbolStats(db, from, to);
+  const dailyStats = getDailyStats(db, from, to);
+  const trades = getTrades(db, { status: 'closed', from, to });
+
+  if (stats.totalTrades === 0) {
+    spinner.warn('No closed trades found for this period.');
+    return;
+  }
+
+  // Generate report
+  const html = generateHTML({
+    periodLabel,
+    from,
+    to,
+    stats,
+    symbolStats,
+    dailyStats,
+    trades,
+    generatedAt: new Date(),
+  });
+
+  // Write report
+  const outputPath = options.output || path.join(
+    getReportsDir(),
+    `trade-report-${format(from, 'yyyy-MM')}.html`
+  );
+
+  fs.writeFileSync(outputPath, html);
+
+  spinner.succeed(`Report generated: ${outputPath}`);
+
+  if (options.open) {
+    await open(outputPath);
+  }
+
+  console.log(chalk.green(`\n✓ Report saved to: ${outputPath}\n`));
+}
+
+function generateHTML(data: {
+  periodLabel: string;
+  from: Date;
+  to: Date;
+  stats: ReturnType<typeof calculateStats>;
+  symbolStats: ReturnType<typeof getSymbolStats>;
+  dailyStats: ReturnType<typeof getDailyStats>;
+  trades: ReturnType<typeof getTrades>;
+  generatedAt: Date;
+}): string {
+  const template = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Trade Report - {{periodLabel}}</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background: #0f172a;
+      color: #e2e8f0;
+      padding: 2rem;
+      line-height: 1.5;
+    }
+    .container { max-width: 1200px; margin: 0 auto; }
+    h1 {
+      font-size: 2rem;
+      margin-bottom: 0.5rem;
+      color: #f8fafc;
+    }
+    h2 {
+      font-size: 1.25rem;
+      margin: 2rem 0 1rem;
+      color: #94a3b8;
+      border-bottom: 1px solid #334155;
+      padding-bottom: 0.5rem;
+    }
+    .subtitle { color: #64748b; margin-bottom: 2rem; }
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    .card {
+      background: #1e293b;
+      border-radius: 8px;
+      padding: 1.25rem;
+      border: 1px solid #334155;
+    }
+    .card-label { color: #94a3b8; font-size: 0.875rem; }
+    .card-value { font-size: 1.5rem; font-weight: 600; margin-top: 0.25rem; }
+    .positive { color: #4ade80; }
+    .negative { color: #f87171; }
+    .neutral { color: #e2e8f0; }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+    }
+    th, td {
+      padding: 0.75rem;
+      text-align: left;
+      border-bottom: 1px solid #334155;
+    }
+    th { color: #94a3b8; font-weight: 500; background: #1e293b; }
+    tr:hover { background: #1e293b; }
+    .text-right { text-align: right; }
+    .badge {
+      display: inline-block;
+      padding: 0.25rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.75rem;
+      font-weight: 500;
+    }
+    .badge-long { background: #166534; color: #4ade80; }
+    .badge-short { background: #991b1b; color: #fca5a5; }
+    .footer {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid #334155;
+      color: #64748b;
+      font-size: 0.875rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>📊 Trade Report</h1>
+    <p class="subtitle">{{periodLabel}}</p>
+
+    <div class="grid">
+      <div class="card">
+        <div class="card-label">Total Trades</div>
+        <div class="card-value neutral">{{stats.totalTrades}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Win Rate</div>
+        <div class="card-value {{#if winRatePositive}}positive{{else}}negative{{/if}}">{{winRate}}%</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Total P&L</div>
+        <div class="card-value {{#if pnlPositive}}positive{{else}}negative{{/if}}">{{totalPnl}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Profit Factor</div>
+        <div class="card-value {{#if pfPositive}}positive{{else}}negative{{/if}}">{{profitFactor}}</div>
+      </div>
+    </div>
+
+    <div class="grid">
+      <div class="card">
+        <div class="card-label">Winning Trades</div>
+        <div class="card-value positive">{{stats.winningTrades}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Losing Trades</div>
+        <div class="card-value negative">{{stats.losingTrades}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Average Win</div>
+        <div class="card-value positive">{{avgWin}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Average Loss</div>
+        <div class="card-value negative">{{avgLoss}}</div>
+      </div>
+    </div>
+
+    <div class="grid">
+      <div class="card">
+        <div class="card-label">Largest Win</div>
+        <div class="card-value positive">{{largestWin}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Largest Loss</div>
+        <div class="card-value negative">{{largestLoss}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Expectancy</div>
+        <div class="card-value {{#if pnlPositive}}positive{{else}}negative{{/if}}">{{expectancy}}</div>
+      </div>
+      <div class="card">
+        <div class="card-label">Current Streak</div>
+        <div class="card-value {{#if streakPositive}}positive{{else}}negative{{/if}}">{{currentStreak}}</div>
+      </div>
+    </div>
+
+    <h2>Performance by Symbol</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Symbol</th>
+          <th class="text-right">Trades</th>
+          <th class="text-right">Win Rate</th>
+          <th class="text-right">Total P&L</th>
+          <th class="text-right">Avg P&L</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each symbolStats}}
+        <tr>
+          <td><strong>{{symbol}}</strong></td>
+          <td class="text-right">{{trades}}</td>
+          <td class="text-right {{#if winRatePositive}}positive{{else}}negative{{/if}}">{{winRate}}%</td>
+          <td class="text-right {{#if pnlPositive}}positive{{else}}negative{{/if}}">{{totalPnl}}</td>
+          <td class="text-right {{#if pnlPositive}}positive{{else}}negative{{/if}}">{{avgPnl}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+
+    <h2>All Trades</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Symbol</th>
+          <th>Side</th>
+          <th class="text-right">Entry</th>
+          <th class="text-right">Exit</th>
+          <th class="text-right">Qty</th>
+          <th class="text-right">P&L</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{#each trades}}
+        <tr>
+          <td>{{date}}</td>
+          <td><strong>{{symbol}}</strong></td>
+          <td><span class="badge {{#if isLong}}badge-long{{else}}badge-short{{/if}}">{{side}}</span></td>
+          <td class="text-right">{{entryPrice}}</td>
+          <td class="text-right">{{exitPrice}}</td>
+          <td class="text-right">{{quantity}}</td>
+          <td class="text-right {{#if pnlPositive}}positive{{else}}negative{{/if}}">{{pnl}}</td>
+        </tr>
+        {{/each}}
+      </tbody>
+    </table>
+
+    <div class="footer">
+      Generated on {{generatedAt}} by Trade Journal CLI
+    </div>
+  </div>
+</body>
+</html>
+`;
+
+  const compiled = Handlebars.compile(template);
+
+  const formatCurrency = (val: number) => {
+    const formatted = Math.abs(val).toFixed(2);
+    return val >= 0 ? `$${formatted}` : `-$${formatted}`;
+  };
+
+  return compiled({
+    periodLabel: data.periodLabel,
+    stats: data.stats,
+    winRate: data.stats.winRate.toFixed(1),
+    winRatePositive: data.stats.winRate >= 50,
+    totalPnl: formatCurrency(data.stats.totalPnl),
+    pnlPositive: data.stats.totalPnl >= 0,
+    profitFactor: data.stats.profitFactor === Infinity ? '∞' : data.stats.profitFactor.toFixed(2),
+    pfPositive: data.stats.profitFactor >= 1,
+    avgWin: formatCurrency(data.stats.averageWin),
+    avgLoss: formatCurrency(data.stats.averageLoss),
+    largestWin: formatCurrency(data.stats.largestWin),
+    largestLoss: formatCurrency(data.stats.largestLoss),
+    expectancy: formatCurrency(data.stats.expectancy),
+    currentStreak: data.stats.currentStreak >= 0
+      ? `${data.stats.currentStreak} wins`
+      : `${Math.abs(data.stats.currentStreak)} losses`,
+    streakPositive: data.stats.currentStreak >= 0,
+    symbolStats: data.symbolStats.map(s => ({
+      symbol: s.symbol,
+      trades: s.trades,
+      winRate: s.winRate.toFixed(1),
+      winRatePositive: s.winRate >= 50,
+      totalPnl: formatCurrency(s.totalPnl),
+      avgPnl: formatCurrency(s.averagePnl),
+      pnlPositive: s.totalPnl >= 0,
+    })),
+    trades: data.trades.map(t => ({
+      date: format(t.entryDate, 'yyyy-MM-dd'),
+      symbol: t.symbol,
+      side: t.side.toUpperCase(),
+      isLong: t.side === 'long',
+      entryPrice: `$${t.entryPrice.toFixed(2)}`,
+      exitPrice: t.exitPrice ? `$${t.exitPrice.toFixed(2)}` : '-',
+      quantity: t.entryQuantity,
+      pnl: formatCurrency(t.pnl ?? 0),
+      pnlPositive: (t.pnl ?? 0) >= 0,
+    })),
+    generatedAt: format(data.generatedAt, 'MMMM d, yyyy h:mm a'),
+  });
+}

--- a/apps/trade-journal/src/commands/stats.ts
+++ b/apps/trade-journal/src/commands/stats.ts
@@ -1,0 +1,249 @@
+// Stats command - display trading statistics
+
+import { Command } from 'commander';
+import chalk from 'chalk';
+import Table from 'cli-table3';
+import {
+  startOfWeek,
+  startOfMonth,
+  startOfYear,
+  subDays,
+  subWeeks,
+  subMonths,
+  format,
+} from 'date-fns';
+import {
+  getDatabase,
+  calculateStats,
+  getSymbolStats,
+  getDailyStats,
+  getTrades,
+} from '../core/database.js';
+import { getDatabasePath, ensureDataDir } from '../core/config.js';
+
+type Period = 'day' | 'week' | 'month' | 'year' | 'all';
+
+export function createStatsCommand(): Command {
+  const cmd = new Command('stats')
+    .description('Display trading statistics')
+    .option('-p, --period <period>', 'Time period: day, week, month, year, all', 'all')
+    .option('-s, --symbol <symbol>', 'Filter by symbol')
+    .option('--from <date>', 'Start date (YYYY-MM-DD)')
+    .option('--to <date>', 'End date (YYYY-MM-DD)')
+    .option('--by-symbol', 'Show stats grouped by symbol')
+    .option('--daily', 'Show daily breakdown')
+    .action(async (options) => {
+      await showStats(options);
+    });
+
+  return cmd;
+}
+
+async function showStats(options: {
+  period: Period;
+  symbol?: string;
+  from?: string;
+  to?: string;
+  bySymbol?: boolean;
+  daily?: boolean;
+}): Promise<void> {
+  ensureDataDir();
+  const db = getDatabase(getDatabasePath());
+
+  // Determine date range
+  let from: Date | undefined;
+  let to: Date | undefined = new Date();
+
+  if (options.from) {
+    from = new Date(options.from);
+  } else {
+    switch (options.period) {
+      case 'day':
+        from = new Date();
+        from.setHours(0, 0, 0, 0);
+        break;
+      case 'week':
+        from = startOfWeek(new Date(), { weekStartsOn: 1 });
+        break;
+      case 'month':
+        from = startOfMonth(new Date());
+        break;
+      case 'year':
+        from = startOfYear(new Date());
+        break;
+      case 'all':
+        from = undefined;
+        break;
+    }
+  }
+
+  if (options.to) {
+    to = new Date(options.to);
+  }
+
+  // Show header
+  const periodLabel = options.from
+    ? `${options.from} to ${options.to || 'now'}`
+    : options.period.toUpperCase();
+
+  console.log(chalk.bold.blue(`
+╔═══════════════════════════════════════════════════════════════╗
+║                    Trade Journal Statistics                    ║
+║                        ${periodLabel.padStart(15).padEnd(20)}                       ║
+╚═══════════════════════════════════════════════════════════════╝
+`));
+
+  // Get overall stats
+  const stats = calculateStats(db, from, to);
+
+  if (stats.totalTrades === 0) {
+    console.log(chalk.yellow('No closed trades found for this period.'));
+    console.log(chalk.dim('\nLog trades with: trade log TSLA --side long --entry 280 --exit 285 --shares 100\n'));
+    return;
+  }
+
+  // Main stats table
+  const mainTable = new Table({
+    chars: { 'mid': '', 'left-mid': '', 'mid-mid': '', 'right-mid': '' },
+  });
+
+  const pnlColor = stats.totalPnl >= 0 ? chalk.green : chalk.red;
+  const winRateColor = stats.winRate >= 50 ? chalk.green : stats.winRate >= 40 ? chalk.yellow : chalk.red;
+
+  mainTable.push(
+    [chalk.bold('Total Trades'), stats.totalTrades.toString()],
+    [chalk.bold('Win Rate'), winRateColor(`${stats.winRate.toFixed(1)}%`)],
+    ['', ''],
+    [chalk.green('Winning Trades'), stats.winningTrades.toString()],
+    [chalk.red('Losing Trades'), stats.losingTrades.toString()],
+    [chalk.dim('Break Even'), stats.breakEvenTrades.toString()],
+    ['', ''],
+    [chalk.bold('Total P&L'), pnlColor(`$${stats.totalPnl.toFixed(2)}`)],
+    [chalk.green('Gross Profit'), chalk.green(`$${stats.grossProfit.toFixed(2)}`)],
+    [chalk.red('Gross Loss'), chalk.red(`$${stats.grossLoss.toFixed(2)}`)],
+    ['', ''],
+    [chalk.bold('Average Win'), chalk.green(`$${stats.averageWin.toFixed(2)}`)],
+    [chalk.bold('Average Loss'), chalk.red(`$${stats.averageLoss.toFixed(2)}`)],
+    [chalk.bold('Average Trade'), pnlColor(`$${stats.averagePnl.toFixed(2)}`)],
+    ['', ''],
+    [chalk.bold('Largest Win'), chalk.green(`$${stats.largestWin.toFixed(2)}`)],
+    [chalk.bold('Largest Loss'), chalk.red(`$${stats.largestLoss.toFixed(2)}`)],
+    ['', ''],
+    [chalk.bold('Profit Factor'), stats.profitFactor === Infinity ? '∞' : stats.profitFactor.toFixed(2)],
+    [chalk.bold('Expectancy'), pnlColor(`$${stats.expectancy.toFixed(2)}`)],
+  );
+
+  if (stats.averageRiskReward !== null) {
+    mainTable.push([chalk.bold('Avg R:R'), `1:${stats.averageRiskReward.toFixed(2)}`]);
+  }
+
+  mainTable.push(
+    ['', ''],
+    [chalk.bold('Current Streak'), stats.currentStreak >= 0 
+      ? chalk.green(`${stats.currentStreak} wins`)
+      : chalk.red(`${Math.abs(stats.currentStreak)} losses`)],
+    [chalk.bold('Longest Win Streak'), chalk.green(stats.longestWinStreak.toString())],
+    [chalk.bold('Longest Lose Streak'), chalk.red(stats.longestLoseStreak.toString())],
+  );
+
+  console.log(mainTable.toString());
+
+  // By symbol breakdown
+  if (options.bySymbol) {
+    console.log(chalk.bold('\n📊 Performance by Symbol:\n'));
+    
+    const symbolStats = getSymbolStats(db, from, to);
+    
+    const symbolTable = new Table({
+      head: [
+        chalk.bold('Symbol'),
+        chalk.bold('Trades'),
+        chalk.bold('Win Rate'),
+        chalk.bold('Total P&L'),
+        chalk.bold('Avg P&L'),
+      ],
+      colAligns: ['left', 'right', 'right', 'right', 'right'],
+    });
+
+    for (const s of symbolStats.slice(0, 20)) {
+      const pnlClr = s.totalPnl >= 0 ? chalk.green : chalk.red;
+      const wrClr = s.winRate >= 50 ? chalk.green : chalk.red;
+      
+      symbolTable.push([
+        chalk.cyan(s.symbol),
+        s.trades.toString(),
+        wrClr(`${s.winRate.toFixed(1)}%`),
+        pnlClr(`$${s.totalPnl.toFixed(2)}`),
+        pnlClr(`$${s.averagePnl.toFixed(2)}`),
+      ]);
+    }
+
+    console.log(symbolTable.toString());
+  }
+
+  // Daily breakdown
+  if (options.daily) {
+    console.log(chalk.bold('\n📅 Daily Performance:\n'));
+    
+    const dailyStats = getDailyStats(db, from, to);
+    
+    const dailyTable = new Table({
+      head: [
+        chalk.bold('Date'),
+        chalk.bold('Trades'),
+        chalk.bold('Wins'),
+        chalk.bold('Losses'),
+        chalk.bold('P&L'),
+      ],
+      colAligns: ['left', 'right', 'right', 'right', 'right'],
+    });
+
+    for (const day of dailyStats.slice(-30)) {
+      const pnlClr = day.pnl >= 0 ? chalk.green : chalk.red;
+      
+      dailyTable.push([
+        format(day.date, 'yyyy-MM-dd (EEE)'),
+        day.trades.toString(),
+        chalk.green(day.wins.toString()),
+        chalk.red(day.losses.toString()),
+        pnlClr(`$${day.pnl.toFixed(2)}`),
+      ]);
+    }
+
+    console.log(dailyTable.toString());
+  }
+
+  // Recent trades preview
+  console.log(chalk.bold('\n📝 Recent Closed Trades:\n'));
+  
+  const recentTrades = getTrades(db, { status: 'closed', from, to, limit: 5 });
+  
+  const recentTable = new Table({
+    head: [
+      chalk.bold('Date'),
+      chalk.bold('Symbol'),
+      chalk.bold('Side'),
+      chalk.bold('Entry'),
+      chalk.bold('Exit'),
+      chalk.bold('P&L'),
+    ],
+    colAligns: ['left', 'left', 'left', 'right', 'right', 'right'],
+  });
+
+  for (const trade of recentTrades) {
+    const pnlClr = (trade.pnl ?? 0) >= 0 ? chalk.green : chalk.red;
+    const sideClr = trade.side === 'long' ? chalk.green : chalk.red;
+    
+    recentTable.push([
+      format(trade.entryDate, 'yyyy-MM-dd'),
+      chalk.cyan(trade.symbol),
+      sideClr(trade.side.toUpperCase()),
+      `$${trade.entryPrice.toFixed(2)}`,
+      trade.exitPrice ? `$${trade.exitPrice.toFixed(2)}` : '-',
+      pnlClr(`$${(trade.pnl ?? 0).toFixed(2)}`),
+    ]);
+  }
+
+  console.log(recentTable.toString());
+  console.log();
+}

--- a/apps/trade-journal/src/core/config.ts
+++ b/apps/trade-journal/src/core/config.ts
@@ -1,0 +1,32 @@
+// Configuration management
+
+import path from 'path';
+import os from 'os';
+import fs from 'fs';
+
+const APP_NAME = 'trade-journal';
+
+export function getDataDir(): string {
+  const dataDir = process.env.TRADE_JOURNAL_DATA_DIR 
+    || path.join(os.homedir(), '.local', 'share', APP_NAME);
+  return dataDir;
+}
+
+export function getDatabasePath(): string {
+  return path.join(getDataDir(), 'trades.db');
+}
+
+export function ensureDataDir(): void {
+  const dataDir = getDataDir();
+  if (!fs.existsSync(dataDir)) {
+    fs.mkdirSync(dataDir, { recursive: true });
+  }
+}
+
+export function getReportsDir(): string {
+  const reportsDir = path.join(getDataDir(), 'reports');
+  if (!fs.existsSync(reportsDir)) {
+    fs.mkdirSync(reportsDir, { recursive: true });
+  }
+  return reportsDir;
+}

--- a/apps/trade-journal/src/core/database.ts
+++ b/apps/trade-journal/src/core/database.ts
@@ -1,0 +1,516 @@
+// Database operations using better-sqlite3
+
+import Database from 'better-sqlite3';
+import { nanoid } from 'nanoid';
+import type { Trade, Import, TradeStats, DailyStats, SymbolStats } from './types.js';
+import { CREATE_TABLES, SCHEMA_VERSION } from './schema.js';
+
+let db: Database.Database | null = null;
+
+export function getDatabase(dbPath: string): Database.Database {
+  if (!db) {
+    db = new Database(dbPath);
+    db.pragma('journal_mode = WAL');
+    initializeDatabase(db);
+  }
+  return db;
+}
+
+export function closeDatabase(): void {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+function initializeDatabase(database: Database.Database): void {
+  database.exec(CREATE_TABLES);
+
+  const versionRow = database.prepare('SELECT version FROM schema_version LIMIT 1').get() as
+    | { version: number }
+    | undefined;
+
+  if (!versionRow) {
+    database.prepare('INSERT INTO schema_version (version) VALUES (?)').run(SCHEMA_VERSION);
+  }
+}
+
+// Trade operations
+
+export function insertTrade(
+  database: Database.Database,
+  trade: Omit<Trade, 'id' | 'createdAt' | 'updatedAt'>
+): Trade {
+  const id = nanoid();
+  
+  database
+    .prepare(
+      `INSERT INTO trades (
+        id, symbol, side, asset_type, status,
+        entry_price, entry_date, entry_quantity,
+        exit_price, exit_date, exit_quantity,
+        pnl, pnl_percent,
+        stop_loss, take_profit, risk_reward_ratio,
+        commission, fees,
+        notes, strategy, tags,
+        import_hash, import_source
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    )
+    .run(
+      id,
+      trade.symbol,
+      trade.side,
+      trade.assetType,
+      trade.status,
+      trade.entryPrice,
+      trade.entryDate.toISOString().split('T')[0],
+      trade.entryQuantity,
+      trade.exitPrice,
+      trade.exitDate?.toISOString().split('T')[0] ?? null,
+      trade.exitQuantity,
+      trade.pnl,
+      trade.pnlPercent,
+      trade.stopLoss,
+      trade.takeProfit,
+      trade.riskRewardRatio,
+      trade.commission,
+      trade.fees,
+      trade.notes,
+      trade.strategy,
+      JSON.stringify(trade.tags),
+      trade.importHash,
+      trade.importSource
+    );
+
+  return getTrade(database, id)!;
+}
+
+export function getTrade(database: Database.Database, id: string): Trade | null {
+  const row = database.prepare('SELECT * FROM trades WHERE id = ?').get(id) as
+    | Record<string, unknown>
+    | undefined;
+  return row ? mapRowToTrade(row) : null;
+}
+
+export function tradeExists(database: Database.Database, importHash: string): boolean {
+  const row = database.prepare('SELECT 1 FROM trades WHERE import_hash = ?').get(importHash);
+  return !!row;
+}
+
+export function getTrades(
+  database: Database.Database,
+  options: {
+    symbol?: string;
+    side?: 'long' | 'short';
+    status?: 'open' | 'closed';
+    from?: Date;
+    to?: Date;
+    limit?: number;
+    offset?: number;
+  } = {}
+): Trade[] {
+  let sql = 'SELECT * FROM trades WHERE 1=1';
+  const params: unknown[] = [];
+
+  if (options.symbol) {
+    sql += ' AND symbol = ?';
+    params.push(options.symbol.toUpperCase());
+  }
+  if (options.side) {
+    sql += ' AND side = ?';
+    params.push(options.side);
+  }
+  if (options.status) {
+    sql += ' AND status = ?';
+    params.push(options.status);
+  }
+  if (options.from) {
+    sql += ' AND entry_date >= ?';
+    params.push(options.from.toISOString().split('T')[0]);
+  }
+  if (options.to) {
+    sql += ' AND entry_date <= ?';
+    params.push(options.to.toISOString().split('T')[0]);
+  }
+
+  sql += ' ORDER BY entry_date DESC';
+
+  if (options.limit) {
+    sql += ' LIMIT ?';
+    params.push(options.limit);
+  }
+  if (options.offset) {
+    sql += ' OFFSET ?';
+    params.push(options.offset);
+  }
+
+  const rows = database.prepare(sql).all(...params) as Record<string, unknown>[];
+  return rows.map(mapRowToTrade);
+}
+
+export function getClosedTrades(
+  database: Database.Database,
+  from?: Date,
+  to?: Date
+): Trade[] {
+  return getTrades(database, { status: 'closed', from, to });
+}
+
+export function updateTrade(
+  database: Database.Database,
+  id: string,
+  updates: Partial<Omit<Trade, 'id' | 'createdAt'>>
+): void {
+  const setClauses: string[] = [];
+  const params: unknown[] = [];
+
+  if (updates.exitPrice !== undefined) {
+    setClauses.push('exit_price = ?');
+    params.push(updates.exitPrice);
+  }
+  if (updates.exitDate !== undefined) {
+    setClauses.push('exit_date = ?');
+    params.push(updates.exitDate?.toISOString().split('T')[0] ?? null);
+  }
+  if (updates.exitQuantity !== undefined) {
+    setClauses.push('exit_quantity = ?');
+    params.push(updates.exitQuantity);
+  }
+  if (updates.status !== undefined) {
+    setClauses.push('status = ?');
+    params.push(updates.status);
+  }
+  if (updates.pnl !== undefined) {
+    setClauses.push('pnl = ?');
+    params.push(updates.pnl);
+  }
+  if (updates.pnlPercent !== undefined) {
+    setClauses.push('pnl_percent = ?');
+    params.push(updates.pnlPercent);
+  }
+  if (updates.notes !== undefined) {
+    setClauses.push('notes = ?');
+    params.push(updates.notes);
+  }
+  if (updates.strategy !== undefined) {
+    setClauses.push('strategy = ?');
+    params.push(updates.strategy);
+  }
+  if (updates.stopLoss !== undefined) {
+    setClauses.push('stop_loss = ?');
+    params.push(updates.stopLoss);
+  }
+  if (updates.takeProfit !== undefined) {
+    setClauses.push('take_profit = ?');
+    params.push(updates.takeProfit);
+  }
+
+  if (setClauses.length === 0) return;
+
+  setClauses.push('updated_at = CURRENT_TIMESTAMP');
+  params.push(id);
+
+  database
+    .prepare(`UPDATE trades SET ${setClauses.join(', ')} WHERE id = ?`)
+    .run(...params);
+}
+
+function mapRowToTrade(row: Record<string, unknown>): Trade {
+  return {
+    id: row.id as string,
+    symbol: row.symbol as string,
+    side: row.side as Trade['side'],
+    assetType: row.asset_type as Trade['assetType'],
+    status: row.status as Trade['status'],
+    entryPrice: row.entry_price as number,
+    entryDate: new Date(row.entry_date as string),
+    entryQuantity: row.entry_quantity as number,
+    exitPrice: row.exit_price as number | null,
+    exitDate: row.exit_date ? new Date(row.exit_date as string) : null,
+    exitQuantity: row.exit_quantity as number | null,
+    pnl: row.pnl as number | null,
+    pnlPercent: row.pnl_percent as number | null,
+    stopLoss: row.stop_loss as number | null,
+    takeProfit: row.take_profit as number | null,
+    riskRewardRatio: row.risk_reward_ratio as number | null,
+    commission: row.commission as number,
+    fees: row.fees as number,
+    notes: row.notes as string | null,
+    strategy: row.strategy as string | null,
+    tags: row.tags ? JSON.parse(row.tags as string) : [],
+    importHash: row.import_hash as string | null,
+    importSource: row.import_source as string | null,
+    createdAt: new Date(row.created_at as string),
+    updatedAt: row.updated_at ? new Date(row.updated_at as string) : null,
+  };
+}
+
+// Statistics
+
+export function calculateStats(
+  database: Database.Database,
+  from?: Date,
+  to?: Date
+): TradeStats {
+  const trades = getClosedTrades(database, from, to);
+  
+  if (trades.length === 0) {
+    return {
+      totalTrades: 0,
+      winningTrades: 0,
+      losingTrades: 0,
+      breakEvenTrades: 0,
+      winRate: 0,
+      totalPnl: 0,
+      grossProfit: 0,
+      grossLoss: 0,
+      averageWin: 0,
+      averageLoss: 0,
+      averagePnl: 0,
+      largestWin: 0,
+      largestLoss: 0,
+      profitFactor: 0,
+      expectancy: 0,
+      averageRiskReward: null,
+      currentStreak: 0,
+      longestWinStreak: 0,
+      longestLoseStreak: 0,
+      periodStart: from ?? new Date(),
+      periodEnd: to ?? new Date(),
+    };
+  }
+
+  const wins = trades.filter(t => (t.pnl ?? 0) > 0);
+  const losses = trades.filter(t => (t.pnl ?? 0) < 0);
+  const breakEven = trades.filter(t => (t.pnl ?? 0) === 0);
+
+  const grossProfit = wins.reduce((sum, t) => sum + (t.pnl ?? 0), 0);
+  const grossLoss = Math.abs(losses.reduce((sum, t) => sum + (t.pnl ?? 0), 0));
+  const totalPnl = grossProfit - grossLoss;
+
+  const averageWin = wins.length > 0 ? grossProfit / wins.length : 0;
+  const averageLoss = losses.length > 0 ? grossLoss / losses.length : 0;
+
+  const pnls = trades.map(t => t.pnl ?? 0);
+  const largestWin = Math.max(...pnls, 0);
+  const largestLoss = Math.min(...pnls, 0);
+
+  // Calculate streaks
+  let currentStreak = 0;
+  let longestWinStreak = 0;
+  let longestLoseStreak = 0;
+  let tempWinStreak = 0;
+  let tempLoseStreak = 0;
+
+  // Sort by date for streak calculation
+  const sortedTrades = [...trades].sort((a, b) => 
+    a.entryDate.getTime() - b.entryDate.getTime()
+  );
+
+  for (const trade of sortedTrades) {
+    if ((trade.pnl ?? 0) > 0) {
+      tempWinStreak++;
+      tempLoseStreak = 0;
+      if (tempWinStreak > longestWinStreak) longestWinStreak = tempWinStreak;
+    } else if ((trade.pnl ?? 0) < 0) {
+      tempLoseStreak++;
+      tempWinStreak = 0;
+      if (tempLoseStreak > longestLoseStreak) longestLoseStreak = tempLoseStreak;
+    }
+  }
+
+  // Current streak (from most recent trade)
+  const lastTrade = sortedTrades[sortedTrades.length - 1];
+  if (lastTrade && (lastTrade.pnl ?? 0) > 0) {
+    currentStreak = tempWinStreak;
+  } else if (lastTrade && (lastTrade.pnl ?? 0) < 0) {
+    currentStreak = -tempLoseStreak;
+  }
+
+  // Risk/Reward
+  const tradesWithRR = trades.filter(t => t.riskRewardRatio !== null);
+  const averageRiskReward = tradesWithRR.length > 0
+    ? tradesWithRR.reduce((sum, t) => sum + (t.riskRewardRatio ?? 0), 0) / tradesWithRR.length
+    : null;
+
+  const dates = trades.map(t => t.entryDate.getTime());
+
+  return {
+    totalTrades: trades.length,
+    winningTrades: wins.length,
+    losingTrades: losses.length,
+    breakEvenTrades: breakEven.length,
+    winRate: trades.length > 0 ? (wins.length / trades.length) * 100 : 0,
+    totalPnl,
+    grossProfit,
+    grossLoss,
+    averageWin,
+    averageLoss,
+    averagePnl: trades.length > 0 ? totalPnl / trades.length : 0,
+    largestWin,
+    largestLoss: Math.abs(largestLoss),
+    profitFactor: grossLoss > 0 ? grossProfit / grossLoss : grossProfit > 0 ? Infinity : 0,
+    expectancy: trades.length > 0 ? totalPnl / trades.length : 0,
+    averageRiskReward,
+    currentStreak,
+    longestWinStreak,
+    longestLoseStreak,
+    periodStart: new Date(Math.min(...dates)),
+    periodEnd: new Date(Math.max(...dates)),
+  };
+}
+
+export function getDailyStats(
+  database: Database.Database,
+  from?: Date,
+  to?: Date
+): DailyStats[] {
+  let sql = `
+    SELECT 
+      entry_date as date,
+      COUNT(*) as trades,
+      SUM(pnl) as pnl,
+      SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END) as wins,
+      SUM(CASE WHEN pnl < 0 THEN 1 ELSE 0 END) as losses
+    FROM trades
+    WHERE status = 'closed'
+  `;
+  const params: unknown[] = [];
+
+  if (from) {
+    sql += ' AND entry_date >= ?';
+    params.push(from.toISOString().split('T')[0]);
+  }
+  if (to) {
+    sql += ' AND entry_date <= ?';
+    params.push(to.toISOString().split('T')[0]);
+  }
+
+  sql += ' GROUP BY entry_date ORDER BY entry_date';
+
+  const rows = database.prepare(sql).all(...params) as Array<{
+    date: string;
+    trades: number;
+    pnl: number;
+    wins: number;
+    losses: number;
+  }>;
+
+  return rows.map(r => ({
+    date: new Date(r.date),
+    trades: r.trades,
+    pnl: r.pnl ?? 0,
+    wins: r.wins,
+    losses: r.losses,
+  }));
+}
+
+export function getSymbolStats(
+  database: Database.Database,
+  from?: Date,
+  to?: Date
+): SymbolStats[] {
+  let sql = `
+    SELECT 
+      symbol,
+      COUNT(*) as trades,
+      SUM(CASE WHEN pnl > 0 THEN 1 ELSE 0 END) as wins,
+      SUM(CASE WHEN pnl < 0 THEN 1 ELSE 0 END) as losses,
+      SUM(pnl) as total_pnl,
+      AVG(pnl) as avg_pnl
+    FROM trades
+    WHERE status = 'closed'
+  `;
+  const params: unknown[] = [];
+
+  if (from) {
+    sql += ' AND entry_date >= ?';
+    params.push(from.toISOString().split('T')[0]);
+  }
+  if (to) {
+    sql += ' AND entry_date <= ?';
+    params.push(to.toISOString().split('T')[0]);
+  }
+
+  sql += ' GROUP BY symbol ORDER BY total_pnl DESC';
+
+  const rows = database.prepare(sql).all(...params) as Array<{
+    symbol: string;
+    trades: number;
+    wins: number;
+    losses: number;
+    total_pnl: number;
+    avg_pnl: number;
+  }>;
+
+  return rows.map(r => ({
+    symbol: r.symbol,
+    trades: r.trades,
+    wins: r.wins,
+    losses: r.losses,
+    winRate: r.trades > 0 ? (r.wins / r.trades) * 100 : 0,
+    totalPnl: r.total_pnl ?? 0,
+    averagePnl: r.avg_pnl ?? 0,
+  }));
+}
+
+// Import tracking
+
+export function createImport(
+  database: Database.Database,
+  imp: Omit<Import, 'id' | 'createdAt'>
+): Import {
+  const id = nanoid();
+  database
+    .prepare(
+      `INSERT INTO imports (id, filename, source, row_count, imported_count, skipped_count)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .run(id, imp.filename, imp.source, imp.rowCount, imp.importedCount, imp.skippedCount);
+
+  return getImport(database, id)!;
+}
+
+export function getImport(database: Database.Database, id: string): Import | null {
+  const row = database.prepare('SELECT * FROM imports WHERE id = ?').get(id) as
+    | Record<string, unknown>
+    | undefined;
+  return row ? mapRowToImport(row) : null;
+}
+
+function mapRowToImport(row: Record<string, unknown>): Import {
+  return {
+    id: row.id as string,
+    filename: row.filename as string,
+    source: row.source as string,
+    rowCount: row.row_count as number,
+    importedCount: row.imported_count as number,
+    skippedCount: row.skipped_count as number,
+    createdAt: new Date(row.created_at as string),
+  };
+}
+
+// Utility to calculate P&L for a trade
+export function calculatePnL(
+  side: 'long' | 'short',
+  entryPrice: number,
+  exitPrice: number,
+  quantity: number,
+  commission: number = 0,
+  fees: number = 0
+): { pnl: number; pnlPercent: number } {
+  let pnl: number;
+  
+  if (side === 'long') {
+    pnl = (exitPrice - entryPrice) * quantity;
+  } else {
+    pnl = (entryPrice - exitPrice) * quantity;
+  }
+  
+  pnl -= (commission + fees);
+  
+  const costBasis = entryPrice * quantity;
+  const pnlPercent = costBasis > 0 ? (pnl / costBasis) * 100 : 0;
+  
+  return { pnl, pnlPercent };
+}

--- a/apps/trade-journal/src/core/schema.ts
+++ b/apps/trade-journal/src/core/schema.ts
@@ -1,0 +1,72 @@
+// Database schema for trade journal
+
+export const SCHEMA_VERSION = 1;
+
+export const CREATE_TABLES = `
+-- Schema version tracking
+CREATE TABLE IF NOT EXISTS schema_version (
+  version INTEGER PRIMARY KEY
+);
+
+-- Trades table
+CREATE TABLE IF NOT EXISTS trades (
+  id TEXT PRIMARY KEY,
+  symbol TEXT NOT NULL,
+  side TEXT NOT NULL CHECK (side IN ('long', 'short')),
+  asset_type TEXT NOT NULL DEFAULT 'stock' CHECK (asset_type IN ('stock', 'option', 'futures', 'forex', 'crypto')),
+  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'closed')),
+  
+  -- Entry
+  entry_price REAL NOT NULL,
+  entry_date TEXT NOT NULL,
+  entry_quantity REAL NOT NULL,
+  
+  -- Exit
+  exit_price REAL,
+  exit_date TEXT,
+  exit_quantity REAL,
+  
+  -- Calculated
+  pnl REAL,
+  pnl_percent REAL,
+  
+  -- Risk management
+  stop_loss REAL,
+  take_profit REAL,
+  risk_reward_ratio REAL,
+  
+  -- Fees
+  commission REAL NOT NULL DEFAULT 0,
+  fees REAL NOT NULL DEFAULT 0,
+  
+  -- Metadata
+  notes TEXT,
+  strategy TEXT,
+  tags TEXT, -- JSON array
+  
+  -- Import tracking
+  import_hash TEXT UNIQUE,
+  import_source TEXT,
+  
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TEXT
+);
+
+-- Imports table
+CREATE TABLE IF NOT EXISTS imports (
+  id TEXT PRIMARY KEY,
+  filename TEXT NOT NULL,
+  source TEXT NOT NULL,
+  row_count INTEGER NOT NULL,
+  imported_count INTEGER NOT NULL,
+  skipped_count INTEGER NOT NULL,
+  created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Indexes for performance
+CREATE INDEX IF NOT EXISTS idx_trades_symbol ON trades(symbol);
+CREATE INDEX IF NOT EXISTS idx_trades_entry_date ON trades(entry_date);
+CREATE INDEX IF NOT EXISTS idx_trades_status ON trades(status);
+CREATE INDEX IF NOT EXISTS idx_trades_side ON trades(side);
+CREATE INDEX IF NOT EXISTS idx_trades_import_hash ON trades(import_hash);
+`;

--- a/apps/trade-journal/src/core/types.ts
+++ b/apps/trade-journal/src/core/types.ts
@@ -1,0 +1,126 @@
+// Trade Journal Types
+
+export type TradeSide = 'long' | 'short';
+export type TradeStatus = 'open' | 'closed';
+export type AssetType = 'stock' | 'option' | 'futures' | 'forex' | 'crypto';
+
+export interface Trade {
+  id: string;
+  symbol: string;
+  side: TradeSide;
+  assetType: AssetType;
+  status: TradeStatus;
+  
+  // Entry
+  entryPrice: number;
+  entryDate: Date;
+  entryQuantity: number;
+  
+  // Exit (null if open)
+  exitPrice: number | null;
+  exitDate: Date | null;
+  exitQuantity: number | null;
+  
+  // Calculated fields
+  pnl: number | null;
+  pnlPercent: number | null;
+  
+  // Risk management
+  stopLoss: number | null;
+  takeProfit: number | null;
+  riskRewardRatio: number | null;
+  
+  // Fees
+  commission: number;
+  fees: number;
+  
+  // Metadata
+  notes: string | null;
+  strategy: string | null;
+  tags: string[];
+  
+  // Import tracking
+  importHash: string | null;
+  importSource: string | null;
+  
+  createdAt: Date;
+  updatedAt: Date | null;
+}
+
+export interface TradeStats {
+  totalTrades: number;
+  winningTrades: number;
+  losingTrades: number;
+  breakEvenTrades: number;
+  
+  winRate: number;
+  
+  totalPnl: number;
+  grossProfit: number;
+  grossLoss: number;
+  
+  averageWin: number;
+  averageLoss: number;
+  averagePnl: number;
+  
+  largestWin: number;
+  largestLoss: number;
+  
+  profitFactor: number;
+  expectancy: number;
+  
+  averageRiskReward: number | null;
+  
+  // Streaks
+  currentStreak: number;
+  longestWinStreak: number;
+  longestLoseStreak: number;
+  
+  // Time-based
+  periodStart: Date;
+  periodEnd: Date;
+}
+
+export interface DailyStats {
+  date: Date;
+  trades: number;
+  pnl: number;
+  wins: number;
+  losses: number;
+}
+
+export interface SymbolStats {
+  symbol: string;
+  trades: number;
+  wins: number;
+  losses: number;
+  winRate: number;
+  totalPnl: number;
+  averagePnl: number;
+}
+
+export interface Import {
+  id: string;
+  filename: string;
+  source: string;
+  rowCount: number;
+  importedCount: number;
+  skippedCount: number;
+  createdAt: Date;
+}
+
+// ThinkorSwim CSV structure
+export interface ToSTradeRow {
+  execTime: Date;
+  spread: string;
+  side: string;
+  qty: number;
+  posEffect: string;
+  symbol: string;
+  expDate: string | null;
+  strike: string | null;
+  type: string | null;
+  price: number;
+  netPrice: number;
+  orderType: string;
+}

--- a/apps/trade-journal/src/import/tos-parser.ts
+++ b/apps/trade-journal/src/import/tos-parser.ts
@@ -1,0 +1,279 @@
+// ThinkorSwim (ToS) CSV Parser
+// Parses trade exports from TD Ameritrade/Schwab ThinkorSwim platform
+
+import fs from 'fs';
+import { parse } from 'csv-parse/sync';
+import { createHash } from 'crypto';
+import type { ToSTradeRow } from '../core/types.js';
+
+export interface ParsedToSTrade {
+  execTime: Date;
+  symbol: string;
+  side: 'long' | 'short';
+  assetType: 'stock' | 'option';
+  quantity: number;
+  price: number;
+  netPrice: number;
+  isOpening: boolean;
+  optionDetails?: {
+    expDate: string;
+    strike: string;
+    type: 'CALL' | 'PUT';
+  };
+  rawRow: Record<string, unknown>;
+}
+
+export interface ToSParseResult {
+  trades: ParsedToSTrade[];
+  errors: string[];
+  totalRows: number;
+}
+
+// ThinkorSwim CSV columns (Account Statement > Transactions)
+const TOS_COLUMNS = [
+  'Exec Time',
+  'Spread',
+  'Side',
+  'Qty',
+  'Pos Effect',
+  'Symbol',
+  'Exp',
+  'Strike',
+  'Type',
+  'Price',
+  'Net Price',
+  'Order Type',
+];
+
+export function parseToSCSV(filePath: string): ToSParseResult {
+  const result: ToSParseResult = {
+    trades: [],
+    errors: [],
+    totalRows: 0,
+  };
+
+  const content = fs.readFileSync(filePath, 'utf-8');
+  
+  // ToS exports can have multiple sections. Find the trades section
+  const lines = content.split('\n');
+  let startIdx = -1;
+  let endIdx = lines.length;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].toLowerCase();
+    // Look for header row containing trade columns
+    if (line.includes('exec time') && line.includes('symbol') && line.includes('qty')) {
+      startIdx = i;
+    }
+    // Stop at next section header or empty lines after data
+    if (startIdx > -1 && i > startIdx + 1 && line.trim() === '') {
+      endIdx = i;
+      break;
+    }
+  }
+
+  if (startIdx === -1) {
+    result.errors.push('Could not find trade data in CSV. Expected ThinkorSwim export format.');
+    return result;
+  }
+
+  const tradeSection = lines.slice(startIdx, endIdx).join('\n');
+
+  let records: Record<string, string>[];
+  try {
+    records = parse(tradeSection, {
+      columns: true,
+      skip_empty_lines: true,
+      trim: true,
+      relax_column_count: true,
+    });
+  } catch (e) {
+    result.errors.push(`CSV parse error: ${(e as Error).message}`);
+    return result;
+  }
+
+  result.totalRows = records.length;
+
+  for (let i = 0; i < records.length; i++) {
+    const row = records[i];
+    
+    try {
+      const trade = parseToSRow(row);
+      if (trade) {
+        result.trades.push(trade);
+      }
+    } catch (e) {
+      result.errors.push(`Row ${i + 2}: ${(e as Error).message}`);
+    }
+  }
+
+  return result;
+}
+
+function parseToSRow(row: Record<string, string>): ParsedToSTrade | null {
+  // Get values with flexible column name matching
+  const execTime = row['Exec Time'] || row['exec time'] || row['EXEC TIME'];
+  const spread = row['Spread'] || row['spread'] || row['SPREAD'] || '';
+  const side = row['Side'] || row['side'] || row['SIDE'];
+  const qty = row['Qty'] || row['qty'] || row['QTY'];
+  const posEffect = row['Pos Effect'] || row['pos effect'] || row['POS EFFECT'];
+  const symbol = row['Symbol'] || row['symbol'] || row['SYMBOL'];
+  const exp = row['Exp'] || row['exp'] || row['EXP'] || '';
+  const strike = row['Strike'] || row['strike'] || row['STRIKE'] || '';
+  const type = row['Type'] || row['type'] || row['TYPE'] || '';
+  const price = row['Price'] || row['price'] || row['PRICE'];
+  const netPrice = row['Net Price'] || row['net price'] || row['NET PRICE'];
+
+  // Skip rows without required data
+  if (!execTime || !symbol || !qty || !price) {
+    return null;
+  }
+
+  // Parse execution time - ToS format: "MM/DD/YY HH:MM:SS" or similar
+  const date = parseToSDate(execTime);
+  if (!date) {
+    throw new Error(`Invalid date format: ${execTime}`);
+  }
+
+  // Parse quantity (can have +/- prefix)
+  const quantity = Math.abs(parseFloat(qty.replace(/[+,]/g, '')));
+  if (isNaN(quantity) || quantity === 0) {
+    return null;
+  }
+
+  // Parse prices
+  const priceVal = parseFloat(price.replace(/[$,]/g, ''));
+  const netPriceVal = parseFloat((netPrice || price).replace(/[$,]/g, ''));
+
+  // Determine if it's an option
+  const isOption = !!(exp && strike && type);
+  
+  // Determine side: BUY_TO_OPEN/BUY = long entry, SELL_TO_OPEN = short entry
+  // BUY_TO_CLOSE = closing short, SELL_TO_CLOSE = closing long
+  const sideUpper = (side || '').toUpperCase();
+  const posEffectUpper = (posEffect || '').toUpperCase();
+  
+  let tradeSide: 'long' | 'short';
+  let isOpening: boolean;
+
+  if (posEffectUpper.includes('OPEN') || posEffectUpper === 'TO OPEN') {
+    isOpening = true;
+    tradeSide = sideUpper.includes('BUY') ? 'long' : 'short';
+  } else if (posEffectUpper.includes('CLOSE') || posEffectUpper === 'TO CLOSE') {
+    isOpening = false;
+    // Closing trade - side is opposite of what we're closing
+    tradeSide = sideUpper.includes('BUY') ? 'short' : 'long';
+  } else {
+    // Default based on side
+    isOpening = sideUpper.includes('BUY');
+    tradeSide = sideUpper.includes('BUY') ? 'long' : 'short';
+  }
+
+  const trade: ParsedToSTrade = {
+    execTime: date,
+    symbol: symbol.toUpperCase(),
+    side: tradeSide,
+    assetType: isOption ? 'option' : 'stock',
+    quantity,
+    price: priceVal,
+    netPrice: netPriceVal,
+    isOpening,
+    rawRow: row,
+  };
+
+  if (isOption) {
+    trade.optionDetails = {
+      expDate: exp,
+      strike: strike,
+      type: type.toUpperCase().includes('CALL') ? 'CALL' : 'PUT',
+    };
+  }
+
+  return trade;
+}
+
+function parseToSDate(dateStr: string): Date | null {
+  // Try various ToS date formats
+  const formats = [
+    // MM/DD/YY HH:MM:SS
+    /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})\s+(\d{1,2}):(\d{2}):(\d{2})$/,
+    // MM/DD/YYYY HH:MM:SS
+    /^(\d{1,2})\/(\d{1,2})\/(\d{4})\s+(\d{1,2}):(\d{2}):(\d{2})$/,
+    // MM/DD/YY
+    /^(\d{1,2})\/(\d{1,2})\/(\d{2,4})$/,
+    // YYYY-MM-DD
+    /^(\d{4})-(\d{2})-(\d{2})$/,
+  ];
+
+  for (const format of formats) {
+    const match = dateStr.match(format);
+    if (match) {
+      if (format.source.startsWith('^(\\d{4})')) {
+        // ISO format
+        return new Date(dateStr);
+      }
+      
+      let [, month, day, year, hour, min, sec] = match;
+      
+      // Handle 2-digit year
+      if (year.length === 2) {
+        const yearNum = parseInt(year);
+        year = (yearNum > 50 ? '19' : '20') + year;
+      }
+      
+      const date = new Date(
+        parseInt(year),
+        parseInt(month) - 1,
+        parseInt(day),
+        parseInt(hour || '0'),
+        parseInt(min || '0'),
+        parseInt(sec || '0')
+      );
+      
+      if (!isNaN(date.getTime())) {
+        return date;
+      }
+    }
+  }
+
+  // Fallback to Date.parse
+  const parsed = new Date(dateStr);
+  return isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function generateImportHash(
+  date: Date,
+  symbol: string,
+  side: string,
+  price: number,
+  quantity: number
+): string {
+  const input = `${date.toISOString()}|${symbol}|${side}|${price}|${quantity}`;
+  return createHash('sha256').update(input).digest('hex').slice(0, 16);
+}
+
+// Group trades by symbol to match entries with exits
+export interface GroupedTrades {
+  symbol: string;
+  entries: ParsedToSTrade[];
+  exits: ParsedToSTrade[];
+}
+
+export function groupTradesBySymbol(trades: ParsedToSTrade[]): GroupedTrades[] {
+  const bySymbol = new Map<string, GroupedTrades>();
+
+  for (const trade of trades) {
+    if (!bySymbol.has(trade.symbol)) {
+      bySymbol.set(trade.symbol, { symbol: trade.symbol, entries: [], exits: [] });
+    }
+
+    const group = bySymbol.get(trade.symbol)!;
+    if (trade.isOpening) {
+      group.entries.push(trade);
+    } else {
+      group.exits.push(trade);
+    }
+  }
+
+  return Array.from(bySymbol.values());
+}

--- a/apps/trade-journal/tsconfig.json
+++ b/apps/trade-journal/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "@tools/typescript-config/base.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "lib": ["ES2022"],
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/trade-journal/tsup.config.ts
+++ b/apps/trade-journal/tsup.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/cli.ts'],
+  format: ['esm'],
+  target: 'node20',
+  outDir: 'dist',
+  clean: true,
+  sourcemap: true,
+  dts: false,
+  splitting: false,
+  shims: true,
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+});

--- a/apps/trade-journal/vitest.config.ts
+++ b/apps/trade-journal/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+    coverage: {
+      reporter: ['text', 'html'],
+      exclude: ['node_modules/', 'dist/'],
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,58 @@ importers:
         specifier: ^6.0.7
         version: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  apps/trade-journal:
+    dependencies:
+      better-sqlite3:
+        specifier: ^11.6.0
+        version: 11.10.0
+      chalk:
+        specifier: ^5.3.0
+        version: 5.6.2
+      cli-table3:
+        specifier: ^0.6.5
+        version: 0.6.5
+      commander:
+        specifier: ^12.1.0
+        version: 12.1.0
+      csv-parse:
+        specifier: ^5.6.0
+        version: 5.6.0
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.8
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.1.6
+      open:
+        specifier: ^10.1.0
+        version: 10.2.0
+      ora:
+        specifier: ^8.1.0
+        version: 8.2.0
+    devDependencies:
+      '@tools/eslint-config':
+        specifier: workspace:*
+        version: link:../../packages/eslint-config
+      '@tools/typescript-config':
+        specifier: workspace:*
+        version: link:../../packages/typescript-config
+      '@types/better-sqlite3':
+        specifier: ^7.6.12
+        version: 7.6.13
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@25.0.3)(jsdom@26.1.0)(lightningcss@1.30.2)
+
   apps/visual-html-builder: {}
 
   packages/audio-components:
@@ -2733,8 +2785,22 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -2747,17 +2813,32 @@ packages:
       vite:
         optional: true
 
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
 
   '@vitest/runner@3.2.4':
     resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
 
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
   '@vitest/snapshot@3.2.4':
     resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
@@ -5108,6 +5189,9 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -5868,8 +5952,16 @@ packages:
     resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
     engines: {node: ^18.0.0 || >=20.0.0}
 
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.4:
@@ -6154,6 +6246,11 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
@@ -6236,6 +6333,31 @@ packages:
       tsx:
         optional: true
       yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
         optional: true
 
   vitest@3.2.4:
@@ -8640,6 +8762,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
   '@vitest/expect@3.2.4':
     dependencies:
       '@types/chai': 5.2.3
@@ -8647,6 +8776,14 @@ snapshots:
       '@vitest/utils': 3.2.4
       chai: 5.3.3
       tinyrainbow: 2.0.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)
 
   '@vitest/mocker@3.2.4(vite@6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0))':
     dependencies:
@@ -8656,9 +8793,18 @@ snapshots:
     optionalDependencies:
       vite: 6.4.1(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
 
   '@vitest/runner@3.2.4':
     dependencies:
@@ -8666,15 +8812,31 @@ snapshots:
       pathe: 2.0.3
       strip-literal: 3.1.0
 
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
   '@vitest/snapshot@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.4
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -11145,6 +11307,8 @@ snapshots:
 
   path-type@4.0.0: {}
 
+  pathe@1.1.2: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
@@ -12074,7 +12238,11 @@ snapshots:
 
   tinypool@1.1.1: {}
 
+  tinyrainbow@1.2.0: {}
+
   tinyrainbow@2.0.0: {}
+
+  tinyspy@3.0.2: {}
 
   tinyspy@4.0.4: {}
 
@@ -12373,6 +12541,24 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@2.1.9(@types/node@25.0.3)(lightningcss@1.30.2):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   vite-node@3.2.4(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
@@ -12440,6 +12626,42 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.30.2
       tsx: 4.21.0
+
+  vitest@2.1.9(@types/node@25.0.3)(jsdom@26.1.0)(lightningcss@1.30.2):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.0.3)(lightningcss@1.30.2))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.0.3)(lightningcss@1.30.2)
+      vite-node: 2.1.9(@types/node@25.0.3)(lightningcss@1.30.2)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.0.3
+      jsdom: 26.1.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
 
   vitest@3.2.4(@types/node@25.0.3)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.30.2)(tsx@4.21.0):
     dependencies:


### PR DESCRIPTION
## Summary

A local-first trading journal CLI for logging trades, calculating statistics, and generating reports.

Closes #19

## Features

- 📝 **Manual Trade Logging** - Log trades with entry/exit prices, quantities, stops, and targets
- 📥 **ThinkorSwim Import** - Parse and import trades from TD Ameritrade/Schwab CSV exports
- 📊 **Statistics** - Win rate, P&L, profit factor, R:R ratio, expectancy, streaks
- 📈 **HTML Reports** - Generate beautiful HTML reports with dark theme
- 🔒 **Local-first** - All data stored in SQLite - your data stays on your machine

## Commands

```bash
# Log a trade
trade log TSLA --side long --entry 280.50 --exit 285.00 --shares 100

# Import from ThinkorSwim
trade import ~/Downloads/tos-trades.csv

# View statistics
trade stats --period week --by-symbol

# Generate HTML report
trade report --month january --open

# List trades
trade list --symbol TSLA --status closed
```

## Statistics Tracked

| Metric | Description |
|--------|-------------|
| Win Rate | Percentage of winning trades |
| Total P&L | Net profit/loss |
| Profit Factor | Gross Profit / Gross Loss |
| Expectancy | Average P&L per trade |
| R:R Ratio | Average risk/reward ratio |
| Streaks | Current, longest win/lose |

## Testing

- ✅ 15 unit tests passing
- ✅ Build succeeds with tsup
- ✅ CLI tested manually

## Technical Details

- TypeScript CLI with Commander.js
- SQLite storage via better-sqlite3
- ThinkorSwim CSV parser with FIFO entry/exit matching
- Handlebars for HTML report templates
- cli-table3 for terminal tables
- date-fns for date manipulation