### PR TITLE
feat: add Chord-Scale Matrix Game Phase 1 (Degree Quiz)

### DIFF
--- a/apps/music-practice/src/components/ChordScaleGame/DegreeQuiz.tsx
+++ b/apps/music-practice/src/components/ChordScaleGame/DegreeQuiz.tsx
@@ -1,0 +1,240 @@
+/**
+ * Degree Quiz Component
+ *
+ * Quick-fire quiz mode that tests knowledge of chord qualities by scale degree.
+ * Example: "What chord quality is on degree 4 of Melodic Minor?" → Answer: "7" (Lydian Dominant)
+ */
+
+import { useState, useEffect } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@hudak/ui/components/card';
+import { Button } from '@hudak/ui/components/button';
+import { Badge } from '@hudak/ui/components/badge';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+  CHORD_SCALE_MATRIX,
+  getDegreeInfo,
+  getAllChordQualities,
+  SCALE_TYPE_NAMES,
+  type ScaleType,
+  type Degree,
+} from '../../data/chord-scale-matrix';
+
+interface DegreeQuizProps {
+  /** Difficulty level - determines which scale types to include */
+  difficulty: 'major' | 'majorMinor' | 'allScales';
+}
+
+interface QuizQuestion {
+  scaleType: ScaleType;
+  degree: Degree;
+  correctAnswer: string;
+  options: string[];
+}
+
+/**
+ * Generate a random quiz question based on difficulty level
+ */
+function generateQuestion(difficulty: 'major' | 'majorMinor' | 'allScales'): QuizQuestion {
+  // Filter scale types based on difficulty
+  const scaleTypes: ScaleType[] =
+    difficulty === 'major'
+      ? ['major']
+      : difficulty === 'majorMinor'
+        ? ['major', 'naturalMinor']
+        : ['major', 'naturalMinor', 'melodicMinor', 'harmonicMinor'];
+
+  // Pick a random scale type
+  const scaleType = scaleTypes[Math.floor(Math.random() * scaleTypes.length)];
+
+  // Pick a random degree (1-7)
+  const degree = (Math.floor(Math.random() * 7) + 1) as Degree;
+
+  // Get the correct answer
+  const entry = getDegreeInfo(scaleType, degree);
+  if (!entry) {
+    throw new Error(`No entry found for ${scaleType} degree ${degree}`);
+  }
+
+  const correctAnswer = entry.chordQuality;
+
+  // Generate 4 multiple choice options (including the correct one)
+  const allQualities = getAllChordQualities();
+  const incorrectOptions = allQualities
+    .filter(q => q !== correctAnswer)
+    .sort(() => Math.random() - 0.5)
+    .slice(0, 3);
+
+  const options = [correctAnswer, ...incorrectOptions].sort(() => Math.random() - 0.5);
+
+  return {
+    scaleType,
+    degree,
+    correctAnswer,
+    options,
+  };
+}
+
+export function DegreeQuiz({ difficulty }: DegreeQuizProps): JSX.Element {
+  const [question, setQuestion] = useState<QuizQuestion | null>(null);
+  const [selectedAnswer, setSelectedAnswer] = useState<string | null>(null);
+  const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
+  const [score, setScore] = useState({ correct: 0, total: 0 });
+  const [streak, setStreak] = useState(0);
+
+  // Generate initial question
+  useEffect(() => {
+    setQuestion(generateQuestion(difficulty));
+  }, [difficulty]);
+
+  const handleAnswer = (answer: string): void => {
+    if (selectedAnswer) return; // Already answered
+
+    setSelectedAnswer(answer);
+    const correct = answer === question?.correctAnswer;
+    setIsCorrect(correct);
+
+    setScore(prev => ({
+      correct: prev.correct + (correct ? 1 : 0),
+      total: prev.total + 1,
+    }));
+
+    setStreak(prev => (correct ? prev + 1 : 0));
+  };
+
+  const nextQuestion = (): void => {
+    setQuestion(generateQuestion(difficulty));
+    setSelectedAnswer(null);
+    setIsCorrect(null);
+  };
+
+  if (!question) {
+    return <div>Loading...</div>;
+  }
+
+  const accuracy = score.total > 0 ? Math.round((score.correct / score.total) * 100) : 0;
+
+  return (
+    <div className="max-w-2xl mx-auto space-y-6">
+      {/* Stats Bar */}
+      <div className="flex gap-4 justify-center">
+        <Card className="flex-1">
+          <CardContent className="pt-4 pb-3 text-center">
+            <div className="text-2xl font-bold text-green-600 dark:text-green-400">
+              {score.correct}/{score.total}
+            </div>
+            <div className="text-xs text-muted-foreground">Correct</div>
+          </CardContent>
+        </Card>
+        <Card className="flex-1">
+          <CardContent className="pt-4 pb-3 text-center">
+            <div className="text-2xl font-bold text-blue-600 dark:text-blue-400">
+              {accuracy}%
+            </div>
+            <div className="text-xs text-muted-foreground">Accuracy</div>
+          </CardContent>
+        </Card>
+        <Card className="flex-1">
+          <CardContent className="pt-4 pb-3 text-center">
+            <div className="text-2xl font-bold text-purple-600 dark:text-purple-400">
+              {streak}
+            </div>
+            <div className="text-xs text-muted-foreground">Streak</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Question Card */}
+      <Card className="border-2">
+        <CardHeader className="pb-4">
+          <Badge variant="outline" className="w-fit mb-2">
+            Degree Quiz
+          </Badge>
+          <CardTitle className="text-2xl">
+            What chord quality is on degree {question.degree} of {SCALE_TYPE_NAMES[question.scaleType]}?
+          </CardTitle>
+          <CardDescription>
+            Select the correct chord quality
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* Answer Options */}
+          <div className="grid grid-cols-2 gap-3">
+            <AnimatePresence mode="wait">
+              {question.options.map((option, index) => {
+                const isSelected = selectedAnswer === option;
+                const showCorrect = selectedAnswer && option === question.correctAnswer;
+                const showIncorrect = selectedAnswer && isSelected && !isCorrect;
+
+                let variant: 'default' | 'outline' | 'secondary' = 'outline';
+                let className = 'h-16 text-lg font-semibold transition-all';
+
+                if (showCorrect) {
+                  className += ' bg-green-500 text-white hover:bg-green-600 border-green-600';
+                } else if (showIncorrect) {
+                  className += ' bg-red-500 text-white hover:bg-red-600 border-red-600';
+                } else if (isSelected) {
+                  variant = 'secondary';
+                }
+
+                return (
+                  <motion.div
+                    key={option}
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                  >
+                    <Button
+                      variant={variant}
+                      className={className}
+                      onClick={() => handleAnswer(option)}
+                      disabled={!!selectedAnswer}
+                    >
+                      {option}
+                    </Button>
+                  </motion.div>
+                );
+              })}
+            </AnimatePresence>
+          </div>
+
+          {/* Feedback */}
+          <AnimatePresence mode="wait">
+            {selectedAnswer && (
+              <motion.div
+                initial={{ opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={{ opacity: 0, height: 0 }}
+                className="space-y-4"
+              >
+                {isCorrect ? (
+                  <div className="p-4 rounded-lg bg-green-50 dark:bg-green-950/30 border-2 border-green-500">
+                    <div className="font-semibold text-green-900 dark:text-green-100">
+                      ✓ Correct!
+                    </div>
+                    <div className="text-sm text-green-800 dark:text-green-200 mt-1">
+                      {getDegreeInfo(question.scaleType, question.degree)?.modeName} mode
+                    </div>
+                  </div>
+                ) : (
+                  <div className="p-4 rounded-lg bg-red-50 dark:bg-red-950/30 border-2 border-red-500">
+                    <div className="font-semibold text-red-900 dark:text-red-100">
+                      ✗ Incorrect
+                    </div>
+                    <div className="text-sm text-red-800 dark:text-red-200 mt-1">
+                      The correct answer is <strong>{question.correctAnswer}</strong> (
+                      {getDegreeInfo(question.scaleType, question.degree)?.modeName})
+                    </div>
+                  </div>
+                )}
+
+                <Button onClick={nextQuestion} size="lg" className="w-full">
+                  Next Question →
+                </Button>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/music-practice/src/components/ChordScaleGame/index.tsx
+++ b/apps/music-practice/src/components/ChordScaleGame/index.tsx
@@ -1,0 +1,167 @@
+/**
+ * Chord-Scale Matrix Game - Main Container
+ *
+ * Based on Jeff Schneider's "Last Chord Scale Charts" system.
+ * Helps internalize chord-scale relationships across all 4 scale families.
+ */
+
+import { useState } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@hudak/ui/components/card';
+import { Button } from '@hudak/ui/components/button';
+import { Badge } from '@hudak/ui/components/badge';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@hudak/ui/components/select';
+import { Label } from '@hudak/ui/components/label';
+import { Brain, Settings2 } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { DegreeQuiz } from './DegreeQuiz';
+
+type GameMode = 'degreeQuiz';
+type Difficulty = 'major' | 'majorMinor' | 'allScales';
+
+export function ChordScaleGame(): JSX.Element {
+  const [gameStarted, setGameStarted] = useState(false);
+  const [gameMode] = useState<GameMode>('degreeQuiz');
+  const [difficulty, setDifficulty] = useState<Difficulty>('major');
+
+  if (!gameStarted) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 flex items-center justify-center p-6">
+        <motion.div
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          className="w-full max-w-2xl"
+        >
+          {/* Header */}
+          <div className="text-center mb-10">
+            <motion.div
+              initial={{ scale: 0.9 }}
+              animate={{ scale: 1 }}
+              className="inline-flex items-center gap-3 mb-4"
+            >
+              <div className="p-3 rounded-2xl bg-gradient-to-br from-violet-500 to-purple-600 shadow-lg">
+                <Brain className="h-8 w-8 text-white" />
+              </div>
+            </motion.div>
+            <h1 className="text-4xl font-bold bg-gradient-to-r from-violet-600 to-purple-600 bg-clip-text text-transparent">
+              Chord-Scale Matrix Trainer
+            </h1>
+            <p className="text-muted-foreground mt-2 text-lg">
+              Master chord-scale relationships for jazz improvisation
+            </p>
+          </div>
+
+          {/* Settings Card */}
+          <Card className="border-2 shadow-xl">
+            <CardHeader className="pb-4">
+              <div className="flex items-center gap-2">
+                <Settings2 className="h-5 w-5 text-muted-foreground" />
+                <CardTitle>Practice Settings</CardTitle>
+              </div>
+              <CardDescription>Configure your practice session</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-8">
+              {/* Game Mode Selection */}
+              <div className="space-y-3">
+                <Label className="text-base font-medium">Game Mode</Label>
+                <div className="grid grid-cols-1 gap-3">
+                  <button
+                    className="relative p-4 rounded-xl border-2 border-violet-500 bg-violet-50 dark:bg-violet-950/30"
+                  >
+                    <div className="flex items-center gap-3">
+                      <Brain className="h-6 w-6 text-violet-600" />
+                      <div className="text-left">
+                        <div className="text-sm font-medium">Degree Quiz</div>
+                        <div className="text-xs text-muted-foreground">
+                          Quick-fire questions: "What chord is on degree 4 of Melodic Minor?"
+                        </div>
+                      </div>
+                      <Badge variant="secondary" className="ml-auto">Active</Badge>
+                    </div>
+                  </button>
+
+                  {/* Coming Soon Game Modes */}
+                  <div className="relative p-4 rounded-xl border-2 border-dashed border-muted opacity-50">
+                    <div className="flex items-center gap-3">
+                      <Brain className="h-6 w-6 text-muted-foreground" />
+                      <div className="text-left">
+                        <div className="text-sm font-medium text-muted-foreground">Chord → Sources</div>
+                        <div className="text-xs text-muted-foreground">
+                          Find all parent scales for a given chord
+                        </div>
+                      </div>
+                      <Badge variant="outline" className="ml-auto">Coming Soon</Badge>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {/* Difficulty Selection */}
+              <div className="space-y-2">
+                <Label htmlFor="difficulty">Difficulty</Label>
+                <Select value={difficulty} onValueChange={(v) => setDifficulty(v as Difficulty)}>
+                  <SelectTrigger id="difficulty">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="major">Major Scale Only</SelectItem>
+                    <SelectItem value="majorMinor">Major + Natural Minor</SelectItem>
+                    <SelectItem value="allScales">All 4 Scale Families</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {difficulty === 'major' && 'Learn the 7 chords of the major scale'}
+                  {difficulty === 'majorMinor' && 'Add natural minor scale chords'}
+                  {difficulty === 'allScales' && 'Master all 28 chord-scale relationships'}
+                </p>
+              </div>
+
+              {/* Start Button */}
+              <motion.div
+                whileHover={{ scale: 1.02 }}
+                whileTap={{ scale: 0.98 }}
+              >
+                <Button
+                  onClick={() => setGameStarted(true)}
+                  size="lg"
+                  className="w-full h-16 text-lg font-semibold bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-700 hover:to-purple-700 shadow-lg"
+                >
+                  <Brain className="mr-3 h-6 w-6" />
+                  Start Practice
+                </Button>
+              </motion.div>
+
+              {/* Info */}
+              <div className="text-center text-sm text-muted-foreground">
+                <p>Based on Jeff Schneider's "Last Chord Scale Charts" system</p>
+              </div>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </div>
+    );
+  }
+
+  // Game started - render the active game mode
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-background via-background to-muted/20 p-6">
+      <div className="max-w-4xl mx-auto">
+        {/* Header with Exit Button */}
+        <div className="flex items-center justify-between mb-8">
+          <div className="flex items-center gap-3">
+            <Brain className="h-6 w-6 text-violet-600" />
+            <h1 className="text-2xl font-bold">Chord-Scale Matrix Trainer</h1>
+          </div>
+          <Button
+            variant="ghost"
+            onClick={() => setGameStarted(false)}
+          >
+            ← Back to Settings
+          </Button>
+        </div>
+
+        {/* Render Game Mode */}
+        {gameMode === 'degreeQuiz' && <DegreeQuiz difficulty={difficulty} />}
+      </div>
+    </div>
+  );
+}

--- a/apps/music-practice/src/data/chord-scale-matrix.ts
+++ b/apps/music-practice/src/data/chord-scale-matrix.ts
@@ -1,0 +1,312 @@
+/**
+ * Chord-Scale Matrix Data Model
+ * Based on Jeff Schneider's "Last Chord Scale Charts" system
+ *
+ * This module contains the complete 28-entry chord-scale matrix
+ * (7 degrees × 4 scale types) that maps chord qualities to their
+ * parent scales and modes.
+ */
+
+export type ScaleType = "major" | "naturalMinor" | "melodicMinor" | "harmonicMinor";
+export type Degree = 1 | 2 | 3 | 4 | 5 | 6 | 7;
+
+/**
+ * Represents a single entry in the chord-scale matrix
+ */
+export interface ChordScaleEntry {
+  scaleType: ScaleType;
+  degree: Degree;
+  chordQuality: string;
+  modeName: string;
+  romanNumeral: string;
+}
+
+/**
+ * The complete chord-scale matrix (28 entries total)
+ *
+ * This is the foundation of the Jeff Schneider system:
+ * - 4 scale families (Major, Natural Minor, Melodic Minor, Harmonic Minor)
+ * - 7 degrees per scale
+ * - Each degree has a specific chord quality and mode
+ */
+export const CHORD_SCALE_MATRIX: ChordScaleEntry[] = [
+  // ============ MAJOR SCALE ============
+  {
+    scaleType: "major",
+    degree: 1,
+    chordQuality: "Maj7",
+    modeName: "Ionian",
+    romanNumeral: "IMaj7"
+  },
+  {
+    scaleType: "major",
+    degree: 2,
+    chordQuality: "m7",
+    modeName: "Dorian",
+    romanNumeral: "iim7"
+  },
+  {
+    scaleType: "major",
+    degree: 3,
+    chordQuality: "m7",
+    modeName: "Phrygian",
+    romanNumeral: "iiim7"
+  },
+  {
+    scaleType: "major",
+    degree: 4,
+    chordQuality: "Maj7",
+    modeName: "Lydian",
+    romanNumeral: "IVMaj7"
+  },
+  {
+    scaleType: "major",
+    degree: 5,
+    chordQuality: "7",
+    modeName: "Mixolydian",
+    romanNumeral: "V7"
+  },
+  {
+    scaleType: "major",
+    degree: 6,
+    chordQuality: "m7",
+    modeName: "Aeolian",
+    romanNumeral: "vim7"
+  },
+  {
+    scaleType: "major",
+    degree: 7,
+    chordQuality: "m7b5",
+    modeName: "Locrian",
+    romanNumeral: "viim7b5"
+  },
+
+  // ============ NATURAL MINOR SCALE ============
+  {
+    scaleType: "naturalMinor",
+    degree: 1,
+    chordQuality: "m7",
+    modeName: "Aeolian",
+    romanNumeral: "im7"
+  },
+  {
+    scaleType: "naturalMinor",
+    degree: 2,
+    chordQuality: "m7b5",
+    modeName: "Locrian",
+    romanNumeral: "iim7b5"
+  },
+  {
+    scaleType: "naturalMinor",
+    degree: 3,
+    chordQuality: "Maj7",
+    modeName: "Ionian",
+    romanNumeral: "bIIIMaj7"
+  },
+  {
+    scaleType: "naturalMinor",
+    degree: 4,
+    chordQuality: "m7",
+    modeName: "Dorian",
+    romanNumeral: "ivm7"
+  },
+  {
+    scaleType: "naturalMinor",
+    degree: 5,
+    chordQuality: "m7",
+    modeName: "Phrygian",
+    romanNumeral: "vm7"
+  },
+  {
+    scaleType: "naturalMinor",
+    degree: 6,
+    chordQuality: "Maj7",
+    modeName: "Lydian",
+    romanNumeral: "bVIMaj7"
+  },
+  {
+    scaleType: "naturalMinor",
+    degree: 7,
+    chordQuality: "7",
+    modeName: "Mixolydian",
+    romanNumeral: "bVII7"
+  },
+
+  // ============ MELODIC MINOR SCALE ============
+  {
+    scaleType: "melodicMinor",
+    degree: 1,
+    chordQuality: "mMaj7",
+    modeName: "Melodic Minor",
+    romanNumeral: "imMaj7"
+  },
+  {
+    scaleType: "melodicMinor",
+    degree: 2,
+    chordQuality: "m7",
+    modeName: "Dorian b2",
+    romanNumeral: "iim7"
+  },
+  {
+    scaleType: "melodicMinor",
+    degree: 3,
+    chordQuality: "Maj7#5",
+    modeName: "Lydian Augmented",
+    romanNumeral: "bIIIMaj7#5"
+  },
+  {
+    scaleType: "melodicMinor",
+    degree: 4,
+    chordQuality: "7",
+    modeName: "Lydian Dominant",
+    romanNumeral: "IV7"
+  },
+  {
+    scaleType: "melodicMinor",
+    degree: 5,
+    chordQuality: "7",
+    modeName: "Mixolydian b6",
+    romanNumeral: "V7"
+  },
+  {
+    scaleType: "melodicMinor",
+    degree: 6,
+    chordQuality: "m7b5",
+    modeName: "Locrian #2",
+    romanNumeral: "vim7b5"
+  },
+  {
+    scaleType: "melodicMinor",
+    degree: 7,
+    chordQuality: "m7b5",
+    modeName: "Super Locrian (Altered)",
+    romanNumeral: "viim7b5"
+  },
+
+  // ============ HARMONIC MINOR SCALE ============
+  {
+    scaleType: "harmonicMinor",
+    degree: 1,
+    chordQuality: "mMaj7",
+    modeName: "Harmonic Minor",
+    romanNumeral: "imMaj7"
+  },
+  {
+    scaleType: "harmonicMinor",
+    degree: 2,
+    chordQuality: "m7b5",
+    modeName: "Locrian #6",
+    romanNumeral: "iim7b5"
+  },
+  {
+    scaleType: "harmonicMinor",
+    degree: 3,
+    chordQuality: "Maj7#5",
+    modeName: "Ionian #5",
+    romanNumeral: "bIIIMaj7#5"
+  },
+  {
+    scaleType: "harmonicMinor",
+    degree: 4,
+    chordQuality: "m7",
+    modeName: "Dorian #4",
+    romanNumeral: "ivm7"
+  },
+  {
+    scaleType: "harmonicMinor",
+    degree: 5,
+    chordQuality: "7",
+    modeName: "Phrygian Dominant",
+    romanNumeral: "V7"
+  },
+  {
+    scaleType: "harmonicMinor",
+    degree: 6,
+    chordQuality: "Maj7",
+    modeName: "Lydian #2",
+    romanNumeral: "bVIMaj7"
+  },
+  {
+    scaleType: "harmonicMinor",
+    degree: 7,
+    chordQuality: "dim7",
+    modeName: "Super Locrian bb7",
+    romanNumeral: "viidim7"
+  },
+];
+
+/**
+ * Get all sources (parent scales) for a given chord quality
+ *
+ * @param chordQuality - The chord quality to search for (e.g., "m7", "Maj7", "7")
+ * @returns Array of ChordScaleEntry objects where this chord quality appears
+ *
+ * @example
+ * // Find all sources for Dm7
+ * const sources = getChordSources("m7");
+ * // Returns entries for:
+ * // - Major scale degrees 2, 3, 6 (Dorian, Phrygian, Aeolian)
+ * // - Natural Minor degrees 1, 4, 5
+ * // - Melodic Minor degree 2
+ * // - Harmonic Minor degree 4
+ */
+export function getChordSources(chordQuality: string): ChordScaleEntry[] {
+  return CHORD_SCALE_MATRIX.filter(entry => entry.chordQuality === chordQuality);
+}
+
+/**
+ * Build all 7 chords for a specific scale type
+ *
+ * @param scaleType - The scale family
+ * @returns Array of all 7 chord entries in order (degree 1-7)
+ *
+ * @example
+ * const chords = buildScaleChords("major");
+ * // Returns: [IMaj7, iim7, iiim7, IVMaj7, V7, vim7, viim7b5]
+ */
+export function buildScaleChords(scaleType: ScaleType): ChordScaleEntry[] {
+  return CHORD_SCALE_MATRIX
+    .filter(entry => entry.scaleType === scaleType)
+    .sort((a, b) => a.degree - b.degree);
+}
+
+/**
+ * Get chord information for a specific scale type and degree
+ *
+ * @param scaleType - The scale family
+ * @param degree - The scale degree (1-7)
+ * @returns The ChordScaleEntry for that degree, or null if not found
+ *
+ * @example
+ * const info = getDegreeInfo("melodicMinor", 4);
+ * // Returns: { chordQuality: "7", modeName: "Lydian Dominant", ... }
+ */
+export function getDegreeInfo(scaleType: ScaleType, degree: Degree): ChordScaleEntry | null {
+  return CHORD_SCALE_MATRIX.find(
+    entry => entry.scaleType === scaleType && entry.degree === degree
+  ) || null;
+}
+
+/**
+ * Get all unique chord qualities in the matrix
+ *
+ * @returns Array of unique chord quality strings
+ *
+ * @example
+ * const qualities = getAllChordQualities();
+ * // Returns: ["Maj7", "m7", "7", "m7b5", "mMaj7", "Maj7#5", "dim7"]
+ */
+export function getAllChordQualities(): string[] {
+  const qualities = new Set(CHORD_SCALE_MATRIX.map(entry => entry.chordQuality));
+  return Array.from(qualities);
+}
+
+/**
+ * Get all scale type display names
+ */
+export const SCALE_TYPE_NAMES: Record<ScaleType, string> = {
+  major: "Major",
+  naturalMinor: "Natural Minor",
+  melodicMinor: "Melodic Minor",
+  harmonicMinor: "Harmonic Minor",
+};

--- a/apps/music-practice/src/routes/chord-scale.tsx
+++ b/apps/music-practice/src/routes/chord-scale.tsx
@@ -1,0 +1,14 @@
+/**
+ * Chord-Scale Matrix Game Route
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { ChordScaleGame } from '../components/ChordScaleGame';
+
+export const Route = createFileRoute('/chord-scale')({
+  component: ChordScaleGameRoute,
+});
+
+function ChordScaleGameRoute() {
+  return <ChordScaleGame />;
+}


### PR DESCRIPTION
Implements Phase 1 of the Chord-Scale Matrix Game from issue #29.

## Changes
- Add complete 28-entry chord-scale data model
- Implement DegreeQuiz component with multiple choice questions
- Create ChordScaleGame container with difficulty settings
- Wire up `/chord-scale` route

Created by Claude Code GitHub Action 🤖