### PR TITLE
fix: puzzle-games GitHub Pages deployment config

### DIFF
--- a/apps/puzzle-games/vite.config.ts
+++ b/apps/puzzle-games/vite.config.ts
@@ -4,6 +4,12 @@ import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
+  base: "/tools/puzzle-games/",
+  build: {
+    outDir: "../../docs/puzzle-games",
+    emptyOutDir: true,
+    sourcemap: true,
+  },
   server: {
     port: 5177,
   },

--- a/scripts/generate-landing.js
+++ b/scripts/generate-landing.js
@@ -58,6 +58,13 @@ const toolMetadata = {
     type: 'web-app',
     hasDeployment: true,
   },
+  'puzzle-games': {
+    name: 'Puzzle Games',
+    description: 'Touch-friendly puzzle games (Sokoban, Word Search, Nonogram) for Theodore, optimized for Daylight Computer e-ink display. Black & white design with large touch targets.',
+    techStack: ['React', 'TypeScript', 'Vite', 'TanStack Router'],
+    type: 'web-app',
+    hasDeployment: true,
+  },
   'local-finance': {
     name: 'Local Finance Analyzer',
     description: 'A privacy-first, local-only personal finance CLI tool with AI-powered transaction categorization and HTML reports. All data stays on your machine.',


### PR DESCRIPTION
## Summary
Fixes #39

This PR adds the necessary configuration for puzzle-games to deploy to GitHub Pages.

## Changes

### 1. `apps/puzzle-games/vite.config.ts`
Added `base` and `build` config for GitHub Pages deployment:
```ts
base: '/tools/puzzle-games/',
build: {
  outDir: '../../docs/puzzle-games',
  emptyOutDir: true,
  sourcemap: true,
},
```

### 2. `scripts/generate-landing.js`
Added puzzle-games to the `toolMetadata` object so it appears on the landing page.

## Result
After merge and deploy, puzzle games will be accessible at:
https://jonathanhudak.github.io/tools/puzzle-games/

## Testing
- ✅ Verified vite.config.ts changes match other deployed apps
- ✅ Local build succeeds with `pnpm build` 
- ✅ Landing page generation includes puzzle-games card