### PR TITLE
fix(puzzle-games): add TanStack Router basepath for GitHub Pages

### DIFF
--- a/apps/puzzle-games/src/main.tsx
+++ b/apps/puzzle-games/src/main.tsx
@@ -4,7 +4,10 @@ import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routeTree.gen";
 import "./index.css";
 
-const router = createRouter({ routeTree });
+const router = createRouter({ 
+  routeTree,
+  basepath: '/tools/puzzle-games'
+});
 
 declare module "@tanstack/react-router" {
   interface Register {


### PR DESCRIPTION
Fixes #41

## Problem
The puzzle-games app was showing a blank page on GitHub Pages because TanStack Router wasn't aware of the `/tools/puzzle-games/` subpath.

While Vite's `base` option correctly handles asset URLs, TanStack Router needs its own `basepath` configuration to match routes properly.

## Solution
Added `basepath: '/tools/puzzle-games'` to the router configuration in `main.tsx`.

## Testing
After merging, https://jonathanhudak.github.io/tools/puzzle-games/ should correctly display the game menu and all routes should work.

---
🍌 Ready for Theodore's Arizona trip puzzles!