### PR TITLE
feat: simplify skills installation with install-skills.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,32 @@ This is a **monorepo** managed with [Turborepo](https://turbo.build/repo) and [p
 | [@tools/typescript-config](./packages/typescript-config/) | Shared TypeScript configurations |
 | [@tools/eslint-config](./packages/eslint-config/) | Shared ESLint configurations |
 
+## Claude Code Skills
+
+This repo ships Claude Code skills you can install into any project.
+
+| Skill | Description |
+|-------|-------------|
+| `difference` | Open any GitHub PR, commit, or compare URL in a local virtualized diff viewer |
+
+**One-liner install** (works from any project):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/jonathanhudak/tools/main/scripts/install-skills.sh | bash
+```
+
+Or, if you already have the repo cloned:
+
+```bash
+# Install into the current project
+./scripts/install-skills.sh
+
+# Install globally (all Claude Code projects)
+./scripts/install-skills.sh --global
+```
+
+Skills are symlinked from `~/.local/share/tools-monorepo` so they stay up-to-date with a simple `git pull` there.
+
 ## Quick Start
 
 ### Prerequisites

--- a/apps/difference/public/install.html
+++ b/apps/difference/public/install.html
@@ -140,7 +140,15 @@ pnpm diff dev        # or: pnpm --filter @hudak/difference dev</code></pre>
         <p class="muted">The launcher is idempotent: it installs dependencies on first run, reuses the dev server if it's already up on port 3010, then prints (and tries to open) the target URL.</p>
 
         <h3>Use it in another project</h3>
-        <p>Copy the <code>.claude/skills/difference/</code> directory into your own repo's <code>.claude/skills/</code>. The skill expects the Difference app at <code>apps/difference</code> and uses <code>pnpm</code>, so it's most useful alongside this monorepo. For arbitrary projects, prefer the hosted app or the local dev server above, and use the <strong>Paste diff</strong> tab with <code>git diff &gt; changes.diff</code>.</p>
+        <p>Run the one-liner below from your project directory. It clones the tools repo to <code>~/.local/share/tools-monorepo</code>, installs its dependencies, and symlinks the <code>difference</code> skill into your project's <code>.claude/skills/</code>:</p>
+        <pre><code>curl -fsSL https://raw.githubusercontent.com/jonathanhudak/tools/main/scripts/install-skills.sh | bash</code></pre>
+        <p>Or, if you already have the repo cloned locally:</p>
+        <pre><code># Install into the current project:
+./scripts/install-skills.sh difference
+
+# Install globally (available in every Claude Code project):
+./scripts/install-skills.sh --global difference</code></pre>
+        <p class="muted">Skills are symlinked, not copied, so a future <code>git pull</code> in <code>~/.local/share/tools-monorepo</code> automatically updates them. Requires Node.js and <code>pnpm</code>.</p>
 
         <h2>Requirements</h2>
         <ul>

--- a/scripts/install-skills.sh
+++ b/scripts/install-skills.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Install Claude Code skills from the tools monorepo.
+#
+# This script clones (or updates) the tools repo to a local store, then symlinks
+# the requested skills into your project's .claude/skills/ directory.  Because
+# skills are symlinked — not copied — they stay up-to-date with the store.
+#
+# Usage (from within a clone of this repo):
+#   ./scripts/install-skills.sh                          # install all skills into CWD
+#   ./scripts/install-skills.sh difference               # install just 'difference'
+#   ./scripts/install-skills.sh --global                 # install to ~/.claude/skills/
+#   ./scripts/install-skills.sh --target /path/to/proj   # install into a specific project
+#
+# One-liner (works from any project, no prior clone needed):
+#   curl -fsSL https://raw.githubusercontent.com/jonathanhudak/tools/main/scripts/install-skills.sh | bash
+#
+# Environment variables:
+#   TOOLS_STORE   Path where the tools repo is cloned (default: ~/.local/share/tools-monorepo)
+set -euo pipefail
+
+REPO_URL="https://github.com/jonathanhudak/tools.git"
+STORE_DIR="${TOOLS_STORE:-$HOME/.local/share/tools-monorepo}"
+TARGET_DIR=""
+GLOBAL=false
+SKILLS=()
+
+usage() {
+  cat <<EOF
+Usage: install-skills.sh [options] [skill ...]
+
+Options:
+  --global          Install to ~/.claude/skills/ (available in every project)
+  --target <dir>    Install into <dir>/.claude/skills/  (default: current directory)
+  --store  <dir>    Where to keep the tools repo clone (default: ~/.local/share/tools-monorepo)
+  --help            Show this help
+
+Skills:
+  Pass one or more skill names to install only those; omit to install all available skills.
+  Currently available: difference
+EOF
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --global)      GLOBAL=true; shift ;;
+    --target)      TARGET_DIR="$2"; shift 2 ;;
+    --store)       STORE_DIR="$2"; shift 2 ;;
+    --help | -h)   usage ;;
+    -*)            echo "Unknown option: $1" >&2; exit 1 ;;
+    *)             SKILLS+=("$1"); shift ;;
+  esac
+done
+
+# Resolve install target
+if $GLOBAL; then
+  TARGET_DIR="$HOME/.claude/skills"
+elif [ -z "$TARGET_DIR" ]; then
+  TARGET_DIR="${PWD}/.claude/skills"
+else
+  TARGET_DIR="${TARGET_DIR%/}/.claude/skills"
+fi
+
+echo "Tools store : $STORE_DIR"
+echo "Install to  : $TARGET_DIR"
+echo ""
+
+# Ensure pnpm is available
+if ! command -v pnpm >/dev/null 2>&1; then
+  echo "Error: pnpm is required. Install it from https://pnpm.io/installation" >&2
+  exit 1
+fi
+
+# Clone or update the tools repo
+if [ -d "$STORE_DIR/.git" ]; then
+  echo "Updating tools repo…"
+  git -C "$STORE_DIR" pull --ff-only --quiet || {
+    echo "(git pull failed — using cached copy)" >&2
+  }
+else
+  echo "Cloning tools repo to $STORE_DIR…"
+  git clone --depth 1 "$REPO_URL" "$STORE_DIR"
+fi
+echo ""
+
+# Install monorepo dependencies so skills can start dev servers
+echo "Installing monorepo dependencies…"
+pnpm --dir "$STORE_DIR" install --frozen-lockfile --prefer-offline 2>&1 | tail -3
+echo ""
+
+SKILLS_SRC="$STORE_DIR/.claude/skills"
+
+# Discover available skills if none were specified
+if [ ${#SKILLS[@]} -eq 0 ]; then
+  while IFS= read -r -d '' d; do
+    SKILLS+=("$(basename "$d")")
+  done < <(find "$SKILLS_SRC" -maxdepth 1 -mindepth 1 -type d -print0 | sort -z)
+fi
+
+if [ ${#SKILLS[@]} -eq 0 ]; then
+  echo "No skills found in $SKILLS_SRC" >&2
+  exit 1
+fi
+
+# Symlink each skill into the target directory
+mkdir -p "$TARGET_DIR"
+
+for skill in "${SKILLS[@]}"; do
+  src="$SKILLS_SRC/$skill"
+  dst="$TARGET_DIR/$skill"
+
+  if [ ! -d "$src" ]; then
+    echo "  SKIP $skill — not found in $SKILLS_SRC"
+    continue
+  fi
+
+  if [ -L "$dst" ]; then
+    echo "  SKIP $skill — already installed at $dst"
+    continue
+  fi
+
+  if [ -e "$dst" ]; then
+    echo "  SKIP $skill — $dst already exists (not a symlink; remove it to reinstall)"
+    continue
+  fi
+
+  ln -s "$src" "$dst"
+  echo "  OK   $skill → $dst"
+done
+
+echo ""
+echo "Done."
+
+if ! $GLOBAL && [ "$TARGET_DIR" != "$HOME/.claude/skills" ]; then
+  echo "Tip: pass --global to install into ~/.claude/skills/ for use across all projects."
+fi


### PR DESCRIPTION
Adds `scripts/install-skills.sh` so you can install Claude Code skills from this monorepo into any project with a single curl command.

Also updates the Difference install page and README with the new one-liner install instructions.

Closes #83

Generated with [Claude Code](https://claude.ai/code)